### PR TITLE
Improve KB styling on mobile

### DIFF
--- a/preview-src/kb-index.adoc
+++ b/preview-src/kb-index.adoc
@@ -1,0 +1,5 @@
+= Knowledge Base
+// the content of this page will be automatically generated from the catalog
+:page-layout: kb-index
+:page-theme: kb
+:page-component: kb

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -135,6 +135,9 @@ page:
     - content: Developer Template
       url: developer.html
       urlType: internal
+    - content: KB
+      url: kb-index.html
+      urlType: internal
     - content: KB Article Template
       url: kb-article.html
       urlType: internal

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -46,6 +46,10 @@ body {
 @media screen and (max-width: 420px) {
   .navbar-brand .navbar-item {
     padding-left: 0.5rem;
+    padding-right: 0.75rem;
+  }
+
+  .navbar-brand .navbar-item:last-child {
     padding-right: 0;
   }
 }

--- a/src/css/kb.css
+++ b/src/css/kb.css
@@ -92,8 +92,13 @@ body.kb .doc .sectionbody {
 }
 
 /* Landing Page */
-body.landing.kb.kb-home main.article {
+body.landing.kb.kb-home .article.paragraph {
   padding: 0;
+}
+
+body.landing.kb.kb-home .sectionbody {
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 body.landing.kb .doc .sectionbody .column {


### PR DESCRIPTION
- Preserve padding between Neo4j logo and "KB" title
- Add a small padding on the "Browser By Category" section

|**Current**|**New**|
|--|--|
|![neo4j com_developer_kb_(Moto G4) (1)](https://user-images.githubusercontent.com/333276/99646934-66c77f80-2a51-11eb-9a3b-0bc1feb7beec.png)|![localhost_5252_kb-index html(Moto G4)](https://user-images.githubusercontent.com/333276/99646635-03d5e880-2a51-11eb-8491-33d1424e03dc.png)
