### PR TITLE
Toolbar add page origin private

### DIFF
--- a/src/partials/edit-this-page-link.hbs
+++ b/src/partials/edit-this-page-link.hbs
@@ -1,5 +1,7 @@
-{{#if (and page.fileUri (not env.CI))}}
-  <div class="edit-this-page"><a href="{{page.fileUri}}">Edit this Page</a></div>
-{{else if (and page.editUrl (or env.FORCE_SHOW_EDIT_PAGE_LINK (not page.origin.private)))}}
-  <div class="edit-this-page"><a href="{{page.editUrl}}">Edit this Page</a></div>
-{{/if}}
+{{#unless page.attributes.origin-private}}
+  {{#if (and page.fileUri (not env.CI))}}
+    <div class="edit-this-page"><a href="{{page.fileUri}}">Edit this Page</a></div>
+  {{else if (and page.editUrl (or env.FORCE_SHOW_EDIT_PAGE_LINK (not page.origin.private)))}}
+    <div class="edit-this-page"><a href="{{page.editUrl}}">Edit this Page</a></div>
+  {{/if}}
+{{/unless}}

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -6,8 +6,8 @@
     {{/with}}
     {{> breadcrumbs}}
     {{> page-versions}}
-    {{#if (not page.attributes.origin-private)}}
+    {{#unless page.attributes.origin-private}}
       {{> edit-this-page-link}}
-    {{/if}}
+    {{/unless}}
   </div>
 </div>

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -6,6 +6,8 @@
     {{/with}}
     {{> breadcrumbs}}
     {{> page-versions}}
-    {{> edit-this-page-link}}
+    {{#if (not page.attributes.origin-private)}}
+      {{> edit-this-page-link}}
+    {{/if}}
   </div>
 </div>

--- a/src/partials/toolbar.hbs
+++ b/src/partials/toolbar.hbs
@@ -6,8 +6,6 @@
     {{/with}}
     {{> breadcrumbs}}
     {{> page-versions}}
-    {{#unless page.attributes.origin-private}}
-      {{> edit-this-page-link}}
-    {{/unless}}
+    {{> edit-this-page-link}}
   </div>
 </div>


### PR DESCRIPTION
In a playbook or asciidoc source file set the attribute `page-origin-private: true` to prevent the 'Edit this page' link from being included in the output.