### PR TITLE
Head fixes

### DIFF
--- a/preview-src/private-page.adoc
+++ b/preview-src/private-page.adoc
@@ -1,0 +1,3 @@
+= Private Page
+:page-no-index:
+:page-no-canonical:

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -156,7 +156,9 @@ page:
     - content: Deprecated
       url: deprecated.html
       urlType: internal
-
+    - content: Private Page
+      url: private-page.html
+      urlType: internal
 
 asciidoc:
   attributes:

--- a/src/partials/head-gtm.hbs
+++ b/src/partials/head-gtm.hbs
@@ -1,0 +1,3 @@
+{{#unless page.attributes.disabletracking}}
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-WK23PSS');</script>
+{{/unless}}

--- a/src/partials/head-info.hbs
+++ b/src/partials/head-info.hbs
@@ -1,6 +1,10 @@
-    {{#with page.canonicalUrl}}
+    {{#unless (ne page.attributes.no-canonical undefined)}}
+    {{#if page.canonicalUrl}}
     <link rel="canonical" href="{{{this}}}">
-    {{/with}}
+    {{else}}
+    <link rel="canonical" href="https://neo4j.com{{{ page.attributes.canonical-root }}}{{ page.url }}">
+    {{/if}}
+    {{/unless}}
     {{#unless (eq page.attributes.pagination undefined)}}
     {{#with page.previous}}
     <link rel="prev" href="{{{relativize ./url}}}">

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -11,9 +11,9 @@
     <meta name="feedback" content="{{{this}}}">
     {{/with}}
 
-    {{!-- Swiftype - TODO: to remove --}}
-    <meta class="swiftype" name="post-type" data-type="enum" content="{{{ or page.attributes.type 'Developer Guide' }}}">
-    <meta class="swiftype" name="neo4j-site" data-type="enum" content="Developer Site">
+    {{!-- Swiftype --}}
+    <meta class="swiftype" name="post-type" data-type="enum" content="{{{ or (or page.attributes.search-type page.attributes.type) 'Developer Guide' }}}">
+    <meta class="swiftype" name="neo4j-site" data-type="enum" content="{{{ or page.attributes.search-site 'Developer Site' }}}">
     <meta class="swiftype" name="main-search-priority" data-type="integer" content="3">
     {{#with page.attributes.environment}}
     <meta class="swiftype" name="environment" data-type="string" content="{{{this}}}">
@@ -35,9 +35,7 @@
     <meta name="twitter:creator" content="@neo4j" />
     <meta name="twitter:site" content="@neo4j" />
     <meta property="og:type" content="{{{ or page.attributes.postttype 'article' }}}" />
-    {{#with (or page.attributes.ogtitle page.title) }}
-    <meta property="og:title" content="{{{detag this}}} - Neo4j Graph Database Platform" />
-    {{/with}}
+    <meta property="og:title" content="{{#with (or page.attributes.ogtitle page.title) }}{{{detag this}}}{{/with}} - {{#with page.component.title}}{{{detag this}}}{{/with}}" />
     <meta property="og:locale" content="{{{ or page.attributes.locale 'en_US' }}}">
     {{#with (or page.attributes.ogimage 'https://dist.neo4j.com/wp-content/uploads/20190822071359/neo4j-database-meta-image.png' )}}
     <meta property="og:image" content="{{{this}}}" />
@@ -45,7 +43,7 @@
     {{#with page.description}}
     <meta property="og:description" content="{{this}}">
     {{/with}}
-
+    <meta property="og:url" content="https://neo4j.com{{ page.attributes.canonical-root }}{{ page.url }}">
     {{#with page.attributes.player}}
     <meta name="twitter:player" content="{{this}}" />
     <meta name="twitter:player:width" content="360" />
@@ -59,8 +57,4 @@
     <meta name="twitter:description" content="{{this}}" />
     {{/with}}
     {{/with}}
-
-    <meta property="og:url" content="https://neo4j.com{{ page.attributes.canonical-root }}{{ page.url }}">
-    <link rel="canonical" href="https://neo4j.com{{ page.attributes.canonical-root }}{{ page.url }}">
-
     <link rel="shortcut icon" href="https://neo4j.com/wp-content/themes/neo4jweb/favicon.ico" />

--- a/src/partials/head-prelude.hbs
+++ b/src/partials/head-prelude.hbs
@@ -2,7 +2,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5, minimum-scale=1">
     <meta name="msvalidate.01" content="B5163518CBE4A854B63801277FE5E35C" />
     <meta name="google-site-verification" content="ucqagxjVuq0lJZeLKs0F5AppzK111lNt3IoxU6mzlJE" />
+    {{#if (ne page.attributes.no-index undefined) }}
+    <meta name="robots" content="noindex" />
+    {{else}}
     <meta name="robots" content="index, follow" />
+    {{/if}}
     <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
     <meta name="bingbot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
 

--- a/src/partials/head-scripts.hbs
+++ b/src/partials/head-scripts.hbs
@@ -1,3 +1,1 @@
-{{#unless page.attributes.disabletracking}}
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-WK23PSS');</script>
-{{/unless}}
+{{! add scripts here }}

--- a/src/partials/head-title.hbs
+++ b/src/partials/head-title.hbs
@@ -1,5 +1,1 @@
-    <title>
-        {{{detag (or page.title defaultPageTitle)}}}
-        {{!-- {{#with site.title}} - {{this}}{{/with}} --}}
-        - Neo4j Graph Database Platform
-    </title>
+    <title>{{{detag (or page.title defaultPageTitle)}}}{{#with page.component.title}} - {{this}}{{/with}}</title>

--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -1,4 +1,5 @@
 {{> head-prelude}}
+{{> head-gtm}}
 {{> head-title}}
 {{> head-info}}
 {{> head-styles}}


### PR DESCRIPTION
This PR includes updates that were requested by the web team.

- There are two possible inclusions of a canonical tag. I've commented one out and added an unless to exclude the other from docs
- Added swiftype tags for docs
- Modified og:title and `<title>...</title>` to match our old format for docs
- Moved head-scripts up
- Updated the toolbar to improve the Docs dropdown section and provide correct links to the Driver Manual or manuals for the current page
