### PR TITLE
Neo4j docs css

### DIFF
--- a/preview-src/deprecated.adoc
+++ b/preview-src/deprecated.adoc
@@ -1,0 +1,23 @@
+[role=deprecated]
+= This entire topic is deprecated
+:page-role: deprecated
+
+[abstract]
+--
+Flags all sections as Deprecated
+--
+
+All headers have 'Deprecated' appended.
+
+== Deprecated Heading 1
+
+Lorem ipsum
+
+== Deprecated Heading 2
+
+Lorem ipsum
+
+== Deprecated Heading 3
+
+Lorem ipsum
+

--- a/preview-src/docs-roles.adoc
+++ b/preview-src/docs-roles.adoc
@@ -1,0 +1,36 @@
+= Docs flags
+:page-role: fabric
+
+[abstract]
+--
+Flags sections as Enterprise Edition, Fabric, Deprecated
+--
+
+Blocks with the appropriate roles have text appended.
+
+[role=fabric]
+== Fabric Heading
+
+Lorem ipsum
+
+[role=enterprise-edition]
+== Enterprise Edition content
+
+Lorem ipsum
+
+[role=deprecated]
+== Deprecated content
+
+Other blocks can have deprecated roles added.
+
+.Example block title
+====
+Example 1 content - this example is not deprecated
+====
+
+[role=deprecated]
+.Example 2 title
+====
+Example 2 content - this example is deprecated
+====
+

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -150,6 +150,12 @@ page:
     - content: Tables
       url: tables.html
       urlType: internal
+    - content: Docs roles
+      url: docs-roles.html
+      urlType: internal
+    - content: Deprecated
+      url: deprecated.html
+      urlType: internal
 
 
 asciidoc:

--- a/src/css/neo4j-docs.css
+++ b/src/css/neo4j-docs.css
@@ -1,0 +1,145 @@
+.doc .paragraph .title {
+  font-weight: var(--body-font-weight-bold);
+}
+
+.doc .listingblock.dot {
+  height: 400px;
+  overflow: scroll;
+  border: 2px solid var(--note-color);
+}
+
+section.deprecated .title::after {
+  bottom: 4px;
+  margin-left: 10px;
+}
+
+body.deprecated article h1::after,
+body.deprecated article h2::after,
+body.deprecated article h3::after,
+body.deprecated article h4::after,
+div.deprecated h2::after,
+div.deprecated h3::after,
+div.deprecated h4::after,
+body.deprecated article dt::after,
+p.deprecated::before,
+section.deprecated .title::after,
+table span.deprecated::after,
+.deprecated > .title::after,
+section.enterprise-edition .title::after,
+body.enterprise-edition article h1::after,
+div.enterprise-edition h2::after,
+div.enterprise-edition h3::after,
+div.enterprise-edition h4::after,
+p.enterprise-edition::before,
+table span.enterprise-edition::after,
+body.fabric article h1::after,
+body.fabric article h2::after,
+body.fabric article h3::after,
+body.fabric article h4::after,
+div.fabric h2::after,
+div.fabric h3::after,
+div.fabric h4::after,
+section.fabric .title::after,
+p.fabric::before,
+table span.fabric::after {
+  text-align: center;
+  font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  font-weight: normal;
+  font-size: 0.6em;
+  position: relative;
+  box-sizing: border-box;
+  padding: 5px 8px;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 6px;
+  bottom: 2px;
+  margin-left: 8px;
+}
+
+body.deprecated article h1::after,
+body.deprecated article h2::after,
+body.deprecated article h3::after,
+body.deprecated article h4::after,
+div.deprecated h2::after,
+div.deprecated h3::after,
+div.deprecated h4::after,
+.deprecated dt::after,
+p.deprecated::before,
+section.deprecated .title::after,
+.deprecated > .title::after,
+table span.deprecated::after {
+  content: "deprecated";
+  color: var(--deprecation-color);
+  border-color: var(--deprecation-color);
+}
+
+body.enterprise-edition article h1::after,
+div.enterprise-edition h2::after,
+div.enterprise-edition h3::after,
+div.enterprise-edition h4::after,
+p.enterprise-edition::before,
+section.enterprise-edition .title::after,
+table span.enterprise-edition::after {
+  content: "Enterprise Edition";
+  color: var(--enterprise-edition-color);
+  border-color: var(--enterprise-edition-color);
+}
+
+body.fabric article h1::after,
+div.fabric h2::after,
+div.fabric h3::after,
+div.fabric h4::after,
+p.fabric::before,
+section.fabric .title::after,
+table span.fabric::after {
+  content: "Fabric";
+  color: var(--fabric-color);
+  border-color: var(--fabric-color);
+}
+
+.admonitionblock td.icon .icon-::before {
+  content: "\f088";
+  color: #f58220;
+}
+
+.doc .admonitionblock.deprecated .icon {
+  background-color: var(--deprecation-color);
+  color: var(--deprecation-on-color);
+}
+
+.doc .admonitionblock.deprecated .icon i::after {
+  content: 'DEPRECATED';
+}
+
+.doc .admonitionblock.deprecated {
+  background-color: var(--colour-pink-200);
+  color: var(--colour-pink-900);
+  border-left-color: var(--colour-pink-600);
+}
+
+.doc .admonitionblock.deprecated pre {
+  background-color: var(--colour-red-100);
+  color: var(--colour-red-700);
+}
+
+.doc .admonitionblock.deprecated a {
+  color: var(--colour-red-600);
+}
+
+.doc pre {
+  font-size: calc(14 / var(--rem-base) * 1rem);
+}
+
+.doc .paragraph.statsonlyqueryresult {
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-size: calc(14 / var(--rem-base) * 1rem);
+  background-color: var(--colour-grey-200);
+  margin: 0;
+  margin-top: -1.5rem;
+  margin-right: 30%;
+  margin-bottom: 1.5rem;
+  margin-left: 2rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-left: 1.5rem;
+}

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -31,3 +31,4 @@
 @import "image-zoom.css";
 @import "spinner.css";
 @import "fonts.css";
+@import "neo4j-docs.css";

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -225,6 +225,12 @@
   --sidebar-background: var(--colour-grey-300);
   --table-border-color: var(--panel-border-color);
   --table-stripe-background: var(--colour-grey-100);
+  --deprecation-color: var(--colour-pink-600);
+  --deprecation-on-color: var(--colour-white);
+  --enterprise-edition-color: var(--colour-green-600);
+  --enterprise-edition-on-color: var(--colour-white);
+  --fabric-color: var(--colour-blue-500);
+  --fabric-on-color: var(--colour-white);
 
   /* footer */
   --footer-line-height: var(--doc-line-height);

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -3,7 +3,7 @@
   <head>
 {{> head defaultPageTitle='Untitled'}}
   </head>
-  <body class="article{{#with (or asciidoc.attributes.role page.role)}} {{{this}}}{{/with}}{{#with (or page.attributes.theme "developer")}} {{{this}}}{{/with}}">
+  <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}{{#with asciidoc.attributes.role}} {{{this}}}{{/with}}{{#with (or page.attributes.theme "developer")}} {{{this}}}{{/with}}">
 {{> header}}
 {{> body}}
 {{> footer}}


### PR DESCRIPTION
Adds css for Neo4j docs, adding a 'deprecated' admonition and allows attributes to be set at the page level to identify content as eg 'Enterprise Edition', 'Fabric', 'Deprecated', and also apply similar styling to h2, h3 etc (eg [here](https://neo4j.com/docs/operations-manual/current/performance/disks-ram-and-other-tips/)).

If you have recommendations for cleaning up the css I will welcome any suggestions!