### PR TITLE
Add link to new Go manual

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -217,6 +217,7 @@
               <span class="project-name">Drivers</span>
               <ul class="project-links">
                 <li><a href="{{#with (docs-driver-manual-url page 'dotnet-manual')}}{{{this}}}{{/with}}" class="project-link">.Net Driver</a></li>
+                <li><a href="{{#with (docs-driver-manual-url page 'go-manual')}}{{{this}}}{{/with}}" class="project-link">Go Driver</a></li>
                 <li><a href="{{#with (docs-driver-manual-url page 'java-manual')}}{{{this}}}{{/with}}" class="project-link">Java Driver</a></li>
                 <li><a href="{{#with (docs-driver-manual-url page 'javascript-manual')}}{{{this}}}{{/with}}" class="project-link">JavaScript Driver</a></li>
                 <li><a href="{{#with (docs-driver-manual-url page 'python-manual')}}{{{this}}}{{/with}}" class="project-link">Python Driver</a></li>


### PR DESCRIPTION
The official Go driver for 4.2 has just been released. This adds a link to the manual in the header.