### PR TITLE
Include additional feedback suggestion to user only for public and editable pages

### DIFF
--- a/src/js/07-feedback.js
+++ b/src/js/07-feedback.js
@@ -55,7 +55,11 @@
     feedback.classList.add('negative')
     feedback.innerHTML = '<form class="form"><div class="header"><p><strong>We&rsquo;re sorry to hear that. How could we improve this page?</strong></p><svg width="14px" height="22px" viewBox="0 0 22 22" role="button" class="cancel" aria-label="Cancel Feedback"><line x1="19.5833333" y1="0.416666667" x2="0.416666667" y2="19.5833333" ></line><line x1="19.5833333" y1="19.5833333" x2="0.416666667" y2="0.416666667" ></line></svg></div><div><input id="missing" type="radio" data-reason="missing" name="specific" value="missing" checked="true"><label for="missing">It has missing information</label></div><div><input id="hard-to-follow" type="radio" data-reason="hard-to-follow" name="specific" value="hard-to-follow"><label for="hard-to-follow">It&rsquo;s hard to follow or confusing</label></div><div><input id="inaccurate" type="radio" data-reason="inaccurate" name="specific" value="inaccurate"><label for="inaccurate">It&rsquo;s inaccurate, out of date, or doesn&rsquo;t work</label></div><div><input id="other" type="radio" data-reason="other" name="specific" value="other"><label for="other">Something else' + edit + '</label></div><div class="more-information"><label for="more-information"><strong>More information</strong></label><textarea id="more-information" type="text" rows="3" cols="50" name="more-information" style="resize:none"></textarea></div><div class="buttons"><input type="button" class="primary" data-submit="submit" value="Submit feedback"><input type="button" class="secondary" data-submit="skip" value="Skip"></div></div>'
 
-    var thankyou = '<div class="header thank-you-positive"><p><strong>Thank you for your feedback!</strong></p><p>We will take this information into account while updating our documentation.</p><p>You can also help us by ' + edit.replace('Edit', 'editing') + '.</p></div>'
+    var thankyou = '<div class="header thank-you-positive"><p><strong>Thank you for your feedback!</strong></p><p>We will take this information into account while updating our documentation.</p>'
+
+    if (editLink) {
+      thankyou += '<p>You can also help us by ' + edit.replace('Edit', 'editing') + '.</p></div>'
+    }
 
     feedback.querySelector('.cancel').addEventListener('click', function (e) {
       e.preventDefault()


### PR DESCRIPTION
The message after negative feedback to help us by editing the page is only applicable for content in a public repo. This adds a condition so the message is displayed only when applicable.