### PR TITLE
Add tabbed sections in GDS documentation

### DIFF
--- a/preview-src/drivers-tabs.adoc
+++ b/preview-src/drivers-tabs.adoc
@@ -1,7 +1,9 @@
-= Tabbed sections in Drivers Manual
+= Tabbed sections in Neo4j Manuals
 
 Up to Neo4j 4.1 the Drivers Manual includes tabs to allow users to choose with driver language sections to display.
 From 4.2 on, the Drivers Manual is split into a separate manual per language.
+
+GDS also uses tabs, but they have a different list of tab separators. Rather than tab on languages, they tab on modes (mutate, stats, stream, train, write) and output tab text as _<mode> mode_ eg _Stream mode_.
 
 == Example drivers manual content
 
@@ -245,4 +247,175 @@ The release notes for the Python Driver are available https://github.com/neo4j/n
 
 ======
 
+====
+
+== Example GDS tabs
+
+.FastRP syntax per mode
+[.tabbed-example]
+====
+
+[.include-with-stream]
+======
+
+.Run FastRP in stream mode on a named graph.
+[source, cypher]
+----
+CALL gds.fastRP.stream(
+  graphName: String,
+  configuration: Map
+) YIELD
+  nodeId: Integer,
+  embedding: List<Float>
+----
+
+.Results
+[opts="header"]
+|===
+| Name      | Type         | Description
+| nodeId    | Integer      | Node ID.
+| embedding | List<Float>  | FastRP node embedding.
+|===
+======
+
+[.include-with-stats]
+======
+
+.Run FastRP in stats mode on a named graph.
+[source, cypher]
+----
+CALL gds.fastRP.stats(
+  graphName: String,
+  configuration: Map
+) YIELD
+  nodeCount: Integer,
+  createMillis: Integer,
+  computeMillis: Integer,
+  configuration: Map
+----
+
+.Results
+[opts="header",cols="1,1,6"]
+|===
+| Name          | Type    | Description
+| nodeCount     | Integer | Number of nodes processed.
+| createMillis  | Integer | Milliseconds for creating the graph.
+| computeMillis | Integer | Milliseconds for running the algorithm.
+| configuration | Map     | Configuration used for running the algorithm.
+|===
+
+======
+
+[.include-with-mutate]
+======
+
+.Run FastRP in mutate mode on a named graph.
+[source, cypher]
+----
+CALL gds.fastRP.mutate(
+  graphName: String,
+  configuration: Map
+) YIELD
+  nodeCount: Integer,
+  nodePropertiesWritten: Integer,
+  createMillis: Integer,
+  computeMillis: Integer,
+  mutateMillis: Integer,
+  configuration: Map
+----
+
+.Results
+[opts="header"]
+|===
+| Name                  | Type    | Description
+| nodeCount             | Integer | Number of nodes processed.
+| nodePropertiesWritten | Integer | Number of node properties written.
+| createMillis          | Integer | Milliseconds for creating the graph.
+| computeMillis         | Integer | Milliseconds for running the algorithm.
+| mutateMillis          | Integer | Milliseconds for adding properties to the in-memory graph.
+| configuration         | Map     | Configuration used for running the algorithm.
+|===
+======
+
+[.include-with-write]
+======
+
+.Run FastRP in write mode on a named graph.
+[source, cypher]
+----
+CALL gds.fastRP.write(
+  graphName: String,
+  configuration: Map
+) YIELD
+  nodeCount: Integer,
+  propertiesWritten: Integer,
+  createMillis: Integer,
+  computeMillis: Integer,
+  writeMillis: Integer,
+  configuration: Map
+----
+
+
+.Results
+[opts="header"]
+|===
+| Name                  | Type    | Description
+| nodeCount             | Integer | Number of nodes processed.
+| nodePropertiesWritten | Integer | Number of node properties written.
+| createMillis          | Integer | Milliseconds for creating the graph.
+| computeMillis         | Integer | Milliseconds for running the algorithm.
+| writeMillis           | Integer | Milliseconds for writing result data back to Neo4j.
+| configuration         | Map     | Configuration used for running the algorithm.
+|===
+
+======
+
+====
+
+== Tab when only one tab is needed
+
+.Collapse Path syntax per mode
+[.tabbed-example]
+====
+
+[.include-with-mutate]
+======
+.Run Collapse Path in mutate mode on a named graph.
+[source, cypher]
+----
+CALL gds.alpha.collapsePath.mutate(
+  graphName: String,
+  configuration: Map
+)
+YIELD
+  createMillis: Integer,
+  computeMillis: Integer,
+  mutateMillis: Integer,
+  relationshipsWritten: Integer,
+  configuration: Map
+----
+
+include::../../common-configuration/common-parameters-named-graph.adoc[]
+
+.General configuration for algorithm execution on a named graph.
+[opts="header",cols="1,1,1m,1,4"]
+|===
+| Name              | Type     | Default | Optional | Description
+| nodeLabels        | String[] | ['*']   | yes      | Filter the named graph using the given node labels.
+| concurrency       | Integer  | 4       | yes      | The number of concurrent threads used for running the algorithm.
+|===
+
+include::specific-configuration.adoc[]
+
+.Results
+[opts="header",cols="1m,1,6"]
+|===
+| Name                  | Type      | Description
+| createMillis          | Integer   | Milliseconds for loading data.
+| computeMillis         | Integer   | Milliseconds for running the algorithm.
+| mutateMillis          | Integer   | Milliseconds for adding properties to the in-memory graph.
+| relationshipsWritten  | Integer   | The number of relationships created by the algorithm.
+| configuration         | Map       | The configuration used for running the algorithm.
+|===
+======
 ====

--- a/preview-src/drivers-tabs.adoc
+++ b/preview-src/drivers-tabs.adoc
@@ -395,8 +395,6 @@ YIELD
   configuration: Map
 ----
 
-include::../../common-configuration/common-parameters-named-graph.adoc[]
-
 .General configuration for algorithm execution on a named graph.
 [opts="header",cols="1,1,1m,1,4"]
 |===
@@ -404,8 +402,6 @@ include::../../common-configuration/common-parameters-named-graph.adoc[]
 | nodeLabels        | String[] | ['*']   | yes      | Filter the named graph using the given node labels.
 | concurrency       | Integer  | 4       | yes      | The number of concurrent threads used for running the algorithm.
 |===
-
-include::specific-configuration.adoc[]
 
 .Results
 [opts="header",cols="1m,1,6"]

--- a/preview-src/drivers-tabs.adoc
+++ b/preview-src/drivers-tabs.adoc
@@ -372,7 +372,24 @@ CALL gds.fastRP.write(
 
 ====
 
-== Tab when only one tab is needed
+== No tab in drivers when only one language
+
+.Driver example
+[.tabbed-example]
+====
+
+[.include-with-dotnet]
+======
+.dotnet code
+[source, cypher]
+----
+CODE GOES HERE
+----
+
+======
+====
+
+== Tab when only one GDS tab is needed
 
 .Collapse Path syntax per mode
 [.tabbed-example]

--- a/src/js/06-tabs-block.js
+++ b/src/js/06-tabs-block.js
@@ -126,7 +126,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // Build an array of elements
       var elements = []
-      var langsFound = []
+      var showSingle = false
 
       // add sections for each language from driver manual html output format
       langList.forEach(function (lang) {
@@ -134,12 +134,12 @@ document.addEventListener('DOMContentLoaded', function () {
           block.setAttribute('data-title', lang)
           block.setAttribute('data-lang', lang)
           elements.push(block)
-          langsFound.push(lang)
+          if (gdsModes.includes(lang)) showSingle = true
         })
       })
 
       // Don't do anything if there's only one tab
-      if (elements.length < 1 || (elements.length === 1 && !gdsModes.includes(langsFound[0]))) {
+      if (elements.length <= 1 && !showSingle) {
         return
       }
 

--- a/src/js/06-tabs-block.js
+++ b/src/js/06-tabs-block.js
@@ -97,7 +97,11 @@ document.addEventListener('DOMContentLoaded', function () {
   //
 
   var defaultLang = 'dotnet'
-  var langList = ['dotnet', 'go', 'java', 'javascript', 'python', 'mutate', 'stats', 'stream', 'train', 'write']
+
+  var driverLangs = ['dotnet', 'go', 'java', 'javascript', 'python']
+  var gdsModes = ['mutate', 'stats', 'stream', 'train', 'write']
+
+  var langList = driverLangs.concat(gdsModes)
 
   var currentLanguage = defaultLang
   if (sessionStorageAvailable) {
@@ -122,6 +126,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // Build an array of elements
       var elements = []
+      var langsFound = []
 
       // add sections for each language from driver manual html output format
       langList.forEach(function (lang) {
@@ -129,11 +134,12 @@ document.addEventListener('DOMContentLoaded', function () {
           block.setAttribute('data-title', lang)
           block.setAttribute('data-lang', lang)
           elements.push(block)
+          langsFound.push(lang)
         })
       })
 
       // Don't do anything if there's only one tab
-      if (elements.length < 1) {
+      if (elements.length < 1 || (elements.length == 1 && driverLangs.includes(langsFound[0]))) {
         return
       }
 

--- a/src/js/06-tabs-block.js
+++ b/src/js/06-tabs-block.js
@@ -15,6 +15,13 @@ document.addEventListener('DOMContentLoaded', function () {
       case 'javascript':
         cased = 'JavaScript'
         break
+      case 'mutate':
+      case 'stats':
+      case 'stream':
+      case 'train':
+      case 'write':
+        cased = capitalizeFirstLetter(lang) + ' mode'
+        break
       default:
         cased = capitalizeFirstLetter(lang)
     }
@@ -90,7 +97,7 @@ document.addEventListener('DOMContentLoaded', function () {
   //
 
   var defaultLang = 'dotnet'
-  var langList = ['dotnet', 'go', 'java', 'javascript', 'python']
+  var langList = ['dotnet', 'go', 'java', 'javascript', 'python', 'mutate', 'stats', 'stream', 'train', 'write']
 
   var currentLanguage = defaultLang
   if (sessionStorageAvailable) {
@@ -126,7 +133,7 @@ document.addEventListener('DOMContentLoaded', function () {
       })
 
       // Don't do anything if there's only one tab
-      if (elements.length <= 1) {
+      if (elements.length < 1) {
         return
       }
 

--- a/src/js/06-tabs-block.js
+++ b/src/js/06-tabs-block.js
@@ -139,7 +139,7 @@ document.addEventListener('DOMContentLoaded', function () {
       })
 
       // Don't do anything if there's only one tab
-      if (elements.length < 1 || (elements.length === 1 && driverLangs.includes(langsFound[0]))) {
+      if (elements.length < 1 || (elements.length === 1 && !gdsModes.includes(langsFound[0]))) {
         return
       }
 

--- a/src/js/06-tabs-block.js
+++ b/src/js/06-tabs-block.js
@@ -139,7 +139,7 @@ document.addEventListener('DOMContentLoaded', function () {
       })
 
       // Don't do anything if there's only one tab
-      if (elements.length < 1 || (elements.length == 1 && driverLangs.includes(langsFound[0]))) {
+      if (elements.length < 1 || (elements.length === 1 && driverLangs.includes(langsFound[0]))) {
         return
       }
 


### PR DESCRIPTION
Adds the GDS modes to the list of 'langs' that can be tabbed.

Also, GDS prefer to display the tab even when there is only one tab, for example in [Collapse Path](https://neo4j.com/docs/graph-data-science/1.5-preview/alpha-algorithms/collapse-path/). This PR displays the single tab if the 'lang' is a GDS mode. 