### PR TITLE
Update global font weight to 400

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /public/
 build/
+yarn.lock

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -248,9 +248,10 @@
   --nav-height: calc(var(--body-min-height) - var(--toolbar-height));
   --nav-height--desktop: var(--body-min-height);
   --nav-panel-height: calc(var(--nav-height) - var(--drawer-height));
-  --nav-panel-height--desktop: calc(
-    var(--nav-height--desktop) - var(--drawer-height)
-  );
+  --nav-panel-height--desktop:
+    calc(
+      var(--nav-height--desktop) - var(--drawer-height)
+    );
   --nav-width: calc(270 / var(--rem-base) * 1rem);
   --toc-top: calc(var(--body-top) + var(--toolbar-height));
   --kb-metadata-top: calc(var(--body-top) + var(--toolbar-height));

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -99,7 +99,7 @@
 
   /* fonts */
   --rem-base: 18; /* used to compute rem value from desired pixel value (e.g., calc(18 / var(--rem-base) * 1rem) = 18px) */
-  --body-font-weight: 200;
+  --body-font-weight: 400;
   --body-font-size: 1.0625em; /* 17px */
   --body-font-size--desktop: 1em; /* 18px */
   --body-font-size--print: 0.9375em; /* 15px */
@@ -140,7 +140,7 @@
   /* nav */
   --nav-background: var(--panel-background);
   --nav-border-color: var(--colour-grey-200);
-  --nav-font-weight: 200;
+  --nav-font-weight: 400;
   --nav_active-font-weight: 400;
   --nav-line-height: 1.35;
   --nav-heading-font-color: var(--colour-grey-500);
@@ -248,7 +248,9 @@
   --nav-height: calc(var(--body-min-height) - var(--toolbar-height));
   --nav-height--desktop: var(--body-min-height);
   --nav-panel-height: calc(var(--nav-height) - var(--drawer-height));
-  --nav-panel-height--desktop: calc(var(--nav-height--desktop) - var(--drawer-height));
+  --nav-panel-height--desktop: calc(
+    var(--nav-height--desktop) - var(--drawer-height)
+  );
   --nav-width: calc(270 / var(--rem-base) * 1rem);
   --toc-top: calc(var(--body-top) + var(--toolbar-height));
   --kb-metadata-top: calc(var(--body-top) + var(--toolbar-height));


### PR DESCRIPTION
This PR updates the body and nav font weight to 400. The var.css file has been updated for this.

The current font weight for body is 200 which is too light and not easily readable. It is also not web accessible and elderly people and people with any eye problems would find it difficult to read. We recently updated the font-weight to 400 of the main neo4j.com website for the same reasons. And we would like to do it for the docs section as well.