### PR TITLE
Alter conditions for word-break text in tables

### DIFF
--- a/preview-src/tables.adoc
+++ b/preview-src/tables.adoc
@@ -160,3 +160,40 @@ a|image::sandbox.png[Neo4j Sandbox,width=500,align=center]
 a|
 Neo4j Sandbox is a hosted Neo4j tool that allows you to run private instances of Neo4j without having to install Neo4j locally. You can choose Neo4j Sandbox usecases that come pre-loaded with datasets and your Neo4j Sandbox instances can be accessed over the internet, making them useful for building sample applications. While Neo4j Browser is the primary way to interact with Neo4j instances hosted by Neo4j Sandbox, for this course you will also connect your sandbox instance to a simple web application.
 |===
+
+== Breaking long text
+
+Long parameter, var, or option names shouldn't wrap
+
+.Results
+[opts="header",cols="1,1,6"]
+|===
+| Name                   | Type      | Description
+| nodes                  | int       | The number of nodes considered.
+| writeProperty          | string    | The property name written back to.
+| createMillis           | int       | Milliseconds for loading data.
+| computeMillis          | int       | Milliseconds for running the algorithm.
+| writeMillis            | int       | Milliseconds for writing result data back.
+| centralityDistribution | Map       | Map containing min, max, mean as well as p50, p75, p90, p95, p99 and p999 percentile values of centrality values.
+|===
+
+In case a value or long string is used in a link but not formatted as code
+
+|===
+| text | link
+| text | link:example.com[bolt.connections,bolt.messages_received,bolt.messages_started,dbms.pool.bolt.free,*dbms.pool.bolt.total_size,*dbms.pool.bolt.total_used,*dbms.pool.bolt.used_heap,*causal_clustering.core.is_leader,*causal_clustering.core.last_leader_message,*causal_clustering.core.replication_attempt]
+|===
+
+The next table includes a large codeblock, which needs to wrap
+
+.metrics.filter
+[cols="<1s,<4"]
+|===
+|Description
+a|Specifies which metrics should be enabled by using a comma separated list of globbing patterns. Only the metrics matching the filter will be enabled. For example '*check_point*,neo4j.page_cache.evictions' will enable any checkpoint metrics and the pagecache eviction metric.
+|Valid values
+a|metrics.filter, a ',' separated list with elements of type 'A simple globbing pattern that can use '*' and '?'.'.
+|Default value
+m|*bolt.connections*,*bolt.messages_received*,*bolt.messages_started*,*dbms.pool.bolt.free,*dbms.pool.bolt.total_size,*dbms.pool.bolt.total_used,*dbms.pool.bolt.used_heap,*causal_clustering.core.is_leader,*causal_clustering.core.last_leader_message,*causal_clustering.core.replication_attempt,*causal_clustering.core.replication_fail,*check_point.duration,*check_point.total_time,*cypher.replan_events,*ids_in_use.node,*ids_in_use.property,*ids_in_use.relationship,*pool.transaction.*.total_used,*pool.transaction.*.used_heap,*pool.transaction.*.used_native,*store.size*,*transaction.active_read,*transaction.active_write,*transaction.committed*,*transaction.last_committed_tx_id,*transaction.peak_concurrent,*transaction.rollbacks*,*page_cache.hit*,*page_cache.page_faults,*page_cache.usage_ratio,*vm.file.descriptors.count,*vm.gc.time.*,*vm.heap.used,*vm.memory.buffer.direct.used,*vm.memory.pool.g1_eden_space,*vm.memory.pool.g1_old_gen,*vm.pause_time,*vm.thread*
+
+|===

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -799,8 +799,9 @@ body {
 }
 
 .doc th.tableblock,
-.doc td.tableblock {
-  word-break: break-word; /* overflow-wrap for table cells; gives space higher precedence than hyphen opportunity */
+.doc td.tableblock code,
+.doc td.tableblock a {
+  word-break: break-word;
 }
 
 .doc pre.has-header {


### PR DESCRIPTION
The default Antora table word-break can cause parameter names to wrap, which does not look good.

```
.doc th.tableblock,
.doc td.tableblock {
  word-break: break-word; /* overflow-wrap for table cells; gives space higher precedence than hyphen opportunity */
}
```

![Untitled](https://user-images.githubusercontent.com/16576682/106940940-1390cf00-671a-11eb-99d0-4ad98b57ada8.png)

This can occur with reasonable column widths specified for a table.

I've spent some time trying to find an alternative, and this update changes the word-break from a condition applied to all table cells, and applies it to code and anchors in the cells instead. This prevents large codeblocks from exapnding the table, and covers the situation where we use a value or parameter of some kind as link text, but where it has not been formatted as code.

I don't know if this is _the_ solution, but I'm yet to find anything better. A spot check hasn't shown me any times where it makes a table look obviously worse.


