### PR TITLE
Reorder GDS modes in tabs

### DIFF
--- a/src/js/08-tabs-block.js
+++ b/src/js/08-tabs-block.js
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var defaultLang = 'dotnet'
 
   var driverLangs = ['dotnet', 'go', 'java', 'javascript', 'python']
-  var gdsModes = ['mutate', 'stats', 'stream', 'train', 'write']
+  var gdsModes = ['train', 'stream', 'stats', 'mutate', 'write']
 
   var langList = driverLangs.concat(gdsModes)
 


### PR DESCRIPTION
The GDS modes are ordered alphabetically when presented in tabs. GDS have requested this is changed to the order as shown in this PR.