### PR TITLE
top-level nav menu for other dev sites

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -313,6 +313,26 @@
             </div>
           </div>
         </div>
+        <div class="navbar-item has-dropdown is-hoverable places">
+          <a class="navbar-link" href="/contribute/">Go to</a>
+
+          <div class="navbar-dropdown">
+
+            <div class="navbar-item project">
+              <a class="project-name" href="https://neo4j.com/graphacademy/" title="Free online courses and certifications">Graph Academy</a>
+            </div>
+            <div class="navbar-item project">
+              <a class="project-name" href="https://community.neo4j.com/" title="Help, Q&A, discussions">Community Forums</a>
+            </div>
+            <div class="navbar-item project">
+              <a class="project-name" href="https://neo4j.com/developer/online-meetup/" title="Global developer conferences and workshops">Online Meetups</a>
+            </div>
+            <div class="navbar-item project">
+              <a class="project-name" href="https://discord.gg/neo4j" title="Online socializing and live events">Discord Chat</a>
+            </div>
+
+          </div>
+        </div>
         <div class="navbar-item is-hoverable try">
           <a class="navbar-link" href="/try-neo4j/">Try Neo4j</a>
         </div>


### PR DESCRIPTION
Proposed new top-level menu to easily navigate to other sites, mirroring the destinations on neo4j.com's top-level "Developer" menu.

Open questions for review:

- is this a good idea?
- does the top-nav become too crowded?
- what's the right name for such a menu? is "Go to" a reasonable choice?

