### PR TITLE
Extend tabs

### DIFF
--- a/preview-src/drivers-tabs.adoc
+++ b/preview-src/drivers-tabs.adoc
@@ -5,6 +5,26 @@ From 4.2 on, the Drivers Manual is split into a separate manual per language.
 
 GDS also uses tabs, but they have a different list of tab separators. Rather than tab on languages, they tab on modes (mutate, stats, stream, train, write) and output tab text as _<mode> mode_ eg _Stream mode_.
 
+[.tabbed-example]
+====
+[.include-with-macos]
+======
+Tab for macOS
+======
+[.include-with-linux]
+======
+Tab for Linux
+======
+[.include-with-windows]
+======
+Tab for Linux
+======
+[.include-with-whatever]
+======
+Tab for whatever
+======
+====
+
 == Example drivers manual content
 
 .Acquire the driver

--- a/src/js/08-tabs-block.js
+++ b/src/js/08-tabs-block.js
@@ -23,6 +23,9 @@ document.addEventListener('DOMContentLoaded', function () {
       case 'write':
         cased = capitalizeFirstLetter(lang) + ' mode'
         break
+      case 'macos':
+        cased = 'macOS'
+        break
       default:
         cased = capitalizeFirstLetter(lang)
     }
@@ -93,26 +96,31 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   //
-  // Tabbed sections in the drivers manual
+  // Tabbed sections
   //
 
-  var defaultLang = 'dotnet'
-
-  var driverLangs = ['dotnet', 'go', 'java', 'javascript', 'python']
   var gdsModes = ['train', 'stream', 'stats', 'mutate', 'write']
+  var tabsList = []
+  var tabMarker = 'include-with-'
+  document.querySelectorAll('[class*="'+tabMarker+'"]').forEach(function (tab) {
+    tab.classList.forEach(function(tabClass) {
+      var tabbable = tabClass.replace(tabMarker,'')
+      if (tabClass.startsWith(tabMarker) && tabsList.indexOf(tabbable) === -1) tabsList.push(tabbable)
+    })
+  })
 
-  var langList = driverLangs.concat(gdsModes)
+  var defaultLang = 'dotnet'
 
   var currentLanguage = defaultLang
   if (sessionStorageAvailable) {
     var searchParams = new URLSearchParams(window.location.search)
     var languageFromParams = searchParams.get('language')
-    if (languageFromParams && langList.includes(languageFromParams.toLocaleLowerCase())) {
+    if (languageFromParams && tabsList.includes(languageFromParams.toLocaleLowerCase())) {
       currentLanguage = languageFromParams.toLocaleLowerCase()
       window.sessionStorage.setItem('code_example_language', currentLanguage)
     } else {
       var storedLanguage = window.sessionStorage.getItem('code_example_language')
-      if (storedLanguage && langList.includes(storedLanguage)) {
+      if (storedLanguage && tabsList.includes(storedLanguage)) {
         currentLanguage = storedLanguage
       }
     }
@@ -129,7 +137,8 @@ document.addEventListener('DOMContentLoaded', function () {
       var showSingle = false
 
       // add sections for each language from driver manual html output format
-      langList.forEach(function (lang) {
+      tabsList.forEach(function (lang) {
+        console.log('checking '+lang)
         tab.querySelectorAll('.include-with-' + lang).forEach(function (block) {
           block.setAttribute('data-title', lang)
           block.setAttribute('data-lang', lang)

--- a/src/js/08-tabs-block.js
+++ b/src/js/08-tabs-block.js
@@ -138,7 +138,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // add sections for each language from driver manual html output format
       tabsList.forEach(function (lang) {
-        console.log('checking ' + lang)
         tab.querySelectorAll('.include-with-' + lang).forEach(function (block) {
           block.setAttribute('data-title', lang)
           block.setAttribute('data-lang', lang)

--- a/src/js/08-tabs-block.js
+++ b/src/js/08-tabs-block.js
@@ -102,9 +102,9 @@ document.addEventListener('DOMContentLoaded', function () {
   var gdsModes = ['train', 'stream', 'stats', 'mutate', 'write']
   var tabsList = []
   var tabMarker = 'include-with-'
-  document.querySelectorAll('[class*="'+tabMarker+'"]').forEach(function (tab) {
-    tab.classList.forEach(function(tabClass) {
-      var tabbable = tabClass.replace(tabMarker,'')
+  document.querySelectorAll('[class*="' + tabMarker + '"]').forEach(function (tab) {
+    tab.classList.forEach(function (tabClass) {
+      var tabbable = tabClass.replace(tabMarker, '')
       if (tabClass.startsWith(tabMarker) && tabsList.indexOf(tabbable) === -1) tabsList.push(tabbable)
     })
   })
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // add sections for each language from driver manual html output format
       tabsList.forEach(function (lang) {
-        console.log('checking '+lang)
+        console.log('checking ' + lang)
         tab.querySelectorAll('.include-with-' + lang).forEach(function (block) {
           block.setAttribute('data-title', lang)
           block.setAttribute('data-lang', lang)


### PR DESCRIPTION
Modifies tabs block so that once you've defined a `[.tabbed-example]` section you can append any text to `include-with-` to define a new tab. Unless stated in the js the tab title is initial-capitalized.

Although I think this can be merged as-is, there are two areas we could improve now/in future

1. For anything other than capitalization of the term, we need to update the switch statement. Is there a better way to handle that?
2. GDS displays a tab when there is only one tab, other projects currently don't. Could we define this with something like a page attribute in the playbook?