### PR TITLE
Add links to new Desktop and Browser manuals

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -147,8 +147,14 @@
             </div>
 
             <div class="navbar-item project">
-              <a class="project-name" href="/docs/bloom-user-guide/current/">Bloom</a>
+              <span class="project-name">User Interface Tools</span>
+              <ul class="project-links">
+                <li><a href="/docs/bloom-user-guide/current/" class="project-link">Bloom</a></li>
+                <li><a href="/docs/browser-manual/current/" class="project-link">Neo4j Browser</a></li>
+                <li><a href="/docs/desktop-manual/current/" class="project-link">Neo4j Desktop</a></li>
+              </ul>
             </div>
+
             <div class="navbar-item project">
               <a class="project-name" href="/docs/graph-data-science/current/">Graph Data Science</a>
             </div>

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -147,7 +147,7 @@
             </div>
 
             <div class="navbar-item project">
-              <span class="project-name">User Interface Tools</span>
+              <span class="project-name">Neo4j UI Tools</span>
               <ul class="project-links">
                 <li><a href="/docs/bloom-user-guide/current/" class="project-link">Bloom</a></li>
                 <li><a href="/docs/browser-manual/current/" class="project-link">Neo4j Browser</a></li>


### PR DESCRIPTION
Adds links to the new Browser Manual and Desktop Manual, and puts them into a section called 'User Interface Tools' with Bloom.