### PR TITLE
fixed link styling for code blocks

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -771,3 +771,27 @@ For more information, see the link:/ops-manual[Operations Manual^]
 [[APOC]]APOC:: xref:apoc[APOC] is a library of procedures and functions that make your life as a Neo4j user easier.
 
 // end::glossary[]
+
+[[test-links]]
+== Links
+
+*Normal text*
+
+. Normal text.
+. Text with `Mono space` snippet.
+
+
+*Text that link to www.example.com*
+
+. Text link:#test-links[anchor to test links] text text.
+. Text link:www.example.com[www.example.com] text text.
+. Text link:www.example.com[`mono space`] text text.
+. Text `link:www.example.com[mono space]` text text.
+
+
+*Text that link to page anchor*
+
+. Text <<test-links>> text text.
+. Text <<test-links,testing link text styling>> text text.
+. Text <<test-links,`testing link text styling monospace`>> text text.
+. Text `<<test-links,testing link text styling monospace>>` text text.

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -148,16 +148,13 @@ body {
   color: var(--link-font-color);
 }
 
-.doc a:hover {
+.doc a:hover,
+.doc a:hover code:hover {
   color: var(--link_hover-font-color);
 }
 
-.doc a:visited {
-  color: var(--link_visited-font-color);
-}
-
-.doc a.unresolved {
-  color: var(--link_unresolved-font-color);
+.doc code a {
+  color: inherit;
 }
 
 .doc i.fa {


### PR DESCRIPTION
The code a and a code will render the same.
Removed the visited styling.