### PR TITLE
Replace hyphens with empty spaces for tabbed examples

### DIFF
--- a/preview-src/drivers-tabs.adoc
+++ b/preview-src/drivers-tabs.adoc
@@ -392,6 +392,107 @@ CALL gds.fastRP.write(
 
 ====
 
+== Example GDS with hyphens in the tab name
+
+.Syntax descriptions of the different operations over node properties
+[.tabbed-example, caption = ]
+====
+
+[.include-with-stream-single-property]
+======
+[source, cypher, role=noplay]
+----
+CALL gds.graph.streamNodeProperty(
+    graphName: String,
+    nodeProperties: String,
+    nodeLabels: String or List of Strings,
+    configuration: Map
+)
+YIELD
+    nodeId: Integer,
+    propertyValue: Integer or Float or List of Integer or List of Float
+----
+
+.Parameters
+[opts="header",cols="1,3,1,5"]
+|===
+| Name           | Type                       | Optional | Description
+| graphName      | String                     | no       | The name under which the graph is stored in the catalog.
+| nodeProperties | String                     | no       | The node property in the graph to stream.
+| nodeLabels     | String or List of Strings  | yes      | The node labels to stream the node properties for graph.
+| configuration  | Map                        | yes      | Additional parameters to configure streamNodeProperties.
+|===
+
+.Configuration
+[opts="header",cols="1,1,1,7"]
+|===
+| Name                   | Type                  | Default | Description
+| concurrency            | Integer               | 4       | The number of concurrent threads. Note, this procedure is always running single-threaded.
+|===
+
+.Results
+[opts="header",cols="2,3,5"]
+|===
+| Name            | Type                                                 | Description
+|nodeId           | Integer                                              | The id of the node.
+.^|propertyValue    a|
+* Integer
+* Float
+* List of Integer
+* List of Float  .^| The stored property value.
+|===
+======
+
+[.include-with-stream]
+======
+[source, cypher, role=noplay]
+----
+CALL gds.graph.streamNodeProperties(
+    graphName: String,
+    nodeProperties: String or List of Strings,
+    nodeLabels: String or List of Strings,
+    configuration: Map
+)
+YIELD
+    nodeId: Integer,
+    nodeProperty: String,
+    propertyValue: Integer or Float or List of Integer or List of Float
+----
+
+.Parameters
+[opts="header",cols="1,3,1,5"]
+|===
+| Name           | Type                       | Optional | Description
+| graphName      | String                     | no       | The name under which the graph is stored in the catalog.
+| nodeProperties | String or List of Strings  | no       | The node properties in the graph to stream.
+| nodeLabels     | String or List of Strings  | yes      | The node labels to stream the node properties for graph.
+| configuration  | Map                        | yes      | Additional parameters to configure streamNodeProperties.
+|===
+
+.Configuration
+[opts="header",cols="1,1,1,7"]
+|===
+| Name                   | Type                  | Default | Description
+| concurrency            | Integer               | 4       | The number of concurrent threads. Note, this procedure is always running single-threaded.
+|===
+
+.Results
+[opts="header",cols="2,3,5"]
+|===
+| Name            | Type                                                 | Description
+|nodeId           | Integer                                              | The id of the node.
+|nodeProperty     | String                                               | The name of the node property.
+.^|propertyValue    a|
+* Integer
+* Float
+* List of Integer
+* List of Float  .^| The stored property value.
+|===
+======
+
+====
+
+
 == No tab in drivers when only one language
 
 .Driver example

--- a/src/js/08-tabs-block.js
+++ b/src/js/08-tabs-block.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', function () {
         cased = 'macOS'
         break
       default:
-        cased = capitalizeFirstLetter(lang)
+        cased = capitalizeFirstLetter(lang.replaceAll('-', ' '))
     }
     return cased
   }


### PR DESCRIPTION
Before this change `.include-with-stream-single-property` results in tab title `Stream-single-property` which is not very user-friendly.