### PR TITLE
Remove overriding margin style for .doc .colist

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -702,7 +702,6 @@ body {
 
 .doc .colist {
   font-size: calc(16 / var(--rem-base) * 1rem);
-  margin: 0.25rem 0 -0.25rem;
 }
 
 .doc .colist > table > tr > :first-child,


### PR DESCRIPTION
The margin is already defined and the override makes the text under the block to get too close to the last element.