### PR TITLE
Example border

### DIFF
--- a/preview-src/example.adoc
+++ b/preview-src/example.adoc
@@ -1,0 +1,133 @@
+= Example blocks
+
+Example blocks should have a background colour in the docs theme
+
+== Example 1
+
+A short example
+
+.This is a short one
+[example]
+====
+Lorem Ipsunm
+====
+
+Some text follows the example
+
+.This is also short
+[example]
+====
+Lorem Ipsunm
+====
+
+And some more text here
+
+== Example 2
+
+A longer example
+
+.A longer example
+[example]
+====
+Let's assume there exists a procedure called `myProc`.
+
+This procedure gives the result `A` and `B` for a user with `EXECUTE PROCEDURE` privilege and `A`, `B` and `C` for a user with `EXECUTE BOOSTED PROCEDURE` privilege.
+
+Now, let's adapt the privileges in examples 1 to 4 to apply to this procedure and show what is returned.
+With the privileges from example 1, granted `EXECUTE PROCEDURE *` and denied `EXECUTE BOOSTED PROCEDURE myProc`, the `myProc` procedure returns the result `A` and `B`.
+
+With the privileges from example 2, granted `EXECUTE BOOSTED PROCEDURE *` and denied `EXECUTE PROCEDURE myProc`, execution of the `myProc` procedure is not allowed.
+
+With the privileges from example 3, granted `EXECUTE BOOSTED PROCEDURE *` and denied `EXECUTE BOOSTED PROCEDURE myProc`, execution of the `myProc` procedure is not allowed.
+
+With the privileges from example 4, granted `EXECUTE PROCEDURE myProc` and `EXECUTE BOOSTED PROCEDURE *` and denied `EXECUTE BOOSTED PROCEDURE myProc`, the `myProc` procedure returns the result `A` and `B`.
+
+For comparison, when only granted `EXECUTE BOOSTED PROCEDURE myProc`, the `myProc` procedure returns the result `A`, `B` and `C`, without needing to be granted the `EXECUTE PROCEDURE myProc` privilege.
+====
+
+A line of text after the longer example
+
+[[manage-databases-cc-commands]]
+== Run Cypher administrative commands from Cypher Shell on a cluster
+
+For the following examples consider a cluster environment formed by 5 members, 3 Core servers, and 2 Read Replicas:
+
+.View the members of a cluster
+====
+
+[source, cypher, role=noplay]
+----
+neo4j@neo4j> CALL dbms.cluster.overview();
+----
+
+[queryresult]
+----
++------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| id        | addresses                                                                    | databases                   | groups |
++------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| "8c...3d" | ["bolt://localhost:7683", "http://localhost:7473", "https://localhost:7483"] | {neo4j: "FOLLOWER", system: "FOLLOWER"}         | []     |
+| "8f...28" | ["bolt://localhost:7681", "http://localhost:7471", "https://localhost:7481"] | {neo4j: "LEADER", system: "LEADER"}                   | []     |
+| "e0...4d" | ["bolt://localhost:7684", "http://localhost:7474", "https://localhost:7484"] | {neo4j: "READ_REPLICA", system: "READ_REPLICA"}     | []     |
+| "1a...64" | ["bolt://localhost:7682", "http://localhost:7472", "https://localhost:7482"] | {neo4j: "FOLLOWER", system: "FOLLOWER"}         | []     |
+| "59...87" | ["bolt://localhost:7685", "http://localhost:7475", "https://localhost:7485"] | {neo4j: "READ_REPLICA", system: "READ_REPLICA"}     | []     |
++------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+5 rows available after 5 ms, consumed after another 0 ms
+----
+
+The leader is currently the instance exposing port `7681` for the `bolt` protocol, and `7471/7481` for the `http/https` protocol.
+
+====
+
+Administrators can connect and execute Cypher commands in the following ways:
+
+.Using the `bolt://` scheme to connect to the Leader:
+====
+[source, cypher, role=noheader]
+----
+$ bin/cypher-shell -a bolt://localhost:7681 -d system -u neo4j -p neo4j1
+----
+
+----
+Connected to Neo4j 4.0.0 at bolt://localhost:7681 as user neo4j.
+Type :help for a list of available commands or :exit to exit the shell.
+Note that Cypher queries must end with a semicolon.
+----
+
+[source, cypher, role=noheader]
+----
+neo4j@system> SHOW DATABASES;
+----
+
+----
++-------------------------------+
+| name     | status   | default |
++-------------------------------+
+| "neo4j"  | "online" | TRUE    |
+| "system" | "online" | FALSE   |
++-------------------------------+
+
+2 rows available after 34 ms, consumed after another 0 ms
+----
+
+[source, cypher, role=noheader]
+----
+neo4j@system> CREATE DATABASE data001;
+----
+
+[queryresult]
+----
+0 rows available after 378 ms, consumed after another 12 ms
+Added 1 nodes, Set 4 properties, Added 1 labels
+neo4j@system> SHOW DATABASES;
++--------------------------------+
+| name      | status   | default |
++--------------------------------+
+| "neo4j"   | "online" | TRUE    |
+| "system"  | "online" | FALSE   |
+| "data001" | "online" | FALSE   |
++--------------------------------+
+
+3 rows available after 2 ms, consumed after another 1 ms
+----
+====

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -156,6 +156,9 @@ page:
     - content: Tables
       url: tables.html
       urlType: internal
+    - content: Examples
+      url: example.html
+      urlType: internal
     - content: Docs roles
       url: docs-roles.html
       urlType: internal

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1160,5 +1160,4 @@ body {
   border: 1px solid var(--color-grey-300);
   /* border-top-left-radius: 0.25rem; */
   /* border-top-right-radius: 0.25rem; */
-
 }

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1154,10 +1154,7 @@ body {
 }
 
 .exampleblock > .content {
-  /* background-color: var(--color-grey-200); */
   margin-top: 0.75rem;
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--color-grey-300);
-  /* border-top-left-radius: 0.25rem; */
-  /* border-top-right-radius: 0.25rem; */
 }

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1152,3 +1152,13 @@ body {
   padding-left: 0;
   list-style-type: none;
 }
+
+.exampleblock > .content {
+  /* background-color: var(--color-grey-200); */
+  margin-top: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-grey-300);
+  /* border-top-left-radius: 0.25rem; */
+  /* border-top-right-radius: 0.25rem; */
+
+}


### PR DESCRIPTION
Adds a border to example blocks to allow them to be distinguished from surrounding content, which becomes useful when example blocks are long and contain other asciidoc blocks.