### PR TITLE
Disable search shortcut when editing input

### DIFF
--- a/src/js/13-search.js
+++ b/src/js/13-search.js
@@ -46,7 +46,12 @@ window.neo4jSearch = (function () {
   }
 
   document.addEventListener('keydown', function (e) {
+    const target = e.target
     if (e.key === '/' && !container.classList.contains(activeClass)) {
+      if (target && target.matches('input, [contenteditable]')) {
+        return
+      }
+
       openSearch()
 
       // Stop an extra slash from being added to the input


### PR DESCRIPTION
Otherwise, we cannot type the character `/` is the "Connection URL" input field on a GraphGist page: https://neo4j.com/graphgists/first-steps-with-cypher/

//cc @jexp 