### PR TITLE
Set fixed height for Safari

### DIFF
--- a/src/css/graphgists.css
+++ b/src/css/graphgists.css
@@ -239,6 +239,8 @@ body.graphgist .graphgist-metadata .field.has-addons a.button {
   box-shadow: none;
   font-size: 1em;
   line-height: 1.5;
+  /* Otherwise, the input field is misaligned with the button in Safari */
+  height: 2.5em;
 }
 
 body.graphgist .graphgist-metadata .field.has-addons .control:not(:last-child) {
@@ -264,6 +266,8 @@ body.graphgist .graphgist-metadata .input {
   font-size: 1em;
   line-height: 1.5;
   padding: calc(0.5em - 1px) calc(0.75em - 1px);
+  /* Otherwise, the input field is misaligned with the button in Safari */
+  height: 2.5em;
 }
 
 body.graphgist .graphgist-metadata .control {


### PR DESCRIPTION
Otherwise, the input is misaligned with the button in Safari: 

<img width="344" alt="Capture d’écran 2021-11-16 à 12 54 07" src="https://user-images.githubusercontent.com/333276/141981028-97f9a359-1fde-48bf-ab69-a3d1f2c14ad0.png">


