### PR TITLE
use innerText of code block for copy

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -430,6 +430,32 @@ Eu mea inani iriure.
 Open the <<NEO4J_HOME>> folder and install <<APOC>>.
 // end::glossary_term[]
 
+[source,xml]
+----
+<meta name="viewport"
+  content="width=device-width, initial-scale=1.0">
+----
+
+[source, shell]
+----
+line of code // <1>
+line of code # <2>
+line of code ;; <3>
+line of code <!--4-->
+----
+<1> A callout behind a line comment for C-style languages.
+<2> A callout behind a line comment for Ruby, Python, Perl, etc.
+<3> A callout behind a line comment for Clojure.
+<4> A callout behind a line comment for XML or SGML languages like HTML.
+
+[source, shell, line-comment=%]
+----
+line of code % <1>
+----
+<1> A callout behind a custom line comment prefix (%).
+
+The next source block contains characters that should be copied and then pasted unescaped (ie `<` and `>`).
+
 [source,json]
 ----
 {

--- a/src/js/06-code.js
+++ b/src/js/06-code.js
@@ -40,7 +40,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var copiedText = 'Copied!'
 
   var cleanCode = function (code, language) {
-    var input = code.replace(/(<([^>]+)>)/gi, '')
+    var input = code
 
     if (language === 'bash' || language === 'sh' || language === 'shell' || language === 'console') {
       input = window.neo4jDocs.copyableCommand(input)
@@ -105,7 +105,8 @@ document.addEventListener('DOMContentLoaded', function () {
     var block = pre.querySelector('code')
     var div = pre.parentNode
 
-    var code = block.innerHTML
+    var code = block.innerText
+
     var language = block.hasAttribute('class') &&
       block.getAttribute('class').match(/language-([a-z0-9-])+/i)[0].replace('language-', '')
 


### PR DESCRIPTION
On pages like [Operations manual -> Clustering](https://neo4j.com/docs/operations-manual/4.3/docker/clustering/), Copy to clipboard resulted in broken code because of character escaping (eg `<` to `&lt;`) and the callouts were included.

Using `element.innerText` looks safe and reliable, keeps characters unescaped, and excludes callouts from the copied content.

 