### PR TITLE
add ogdescription as detectable page attribute

### DIFF
--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -34,7 +34,7 @@
     {{#with (or page.attributes.ogimage 'https://dist.neo4j.com/wp-content/uploads/20210423062553/neo4j-social-share-21.png' )}}
     <meta property="og:image" content="{{{this}}}" />
     {{/with}}
-    {{#with page.description}}
+    {{#with (or page.attributes.ogdescription page.description )}}
     <meta property="og:description" content="{{this}}">
     {{/with}}
     <meta property="og:url" content="https://neo4j.com{{ page.attributes.canonical-root }}{{ page.url }}">


### PR DESCRIPTION
Allows page attributes specified in the header to be used in meta tags:

```
:page-ogdescription: This description is used in the og:descrption meta tag
:page-ogtitle: This title is used in the og:title meta tag
```

(ogtitle is already available in the ui - this adds ogdescription)