### PR TITLE
Add AuraDS to docs drop-down

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -161,9 +161,10 @@
             </div>
 
             <div class="navbar-item project">
-              <a class="project-name" href="/docs/aura/current/">Neo4j Aura</a>
+              <a class="project-name" href="/docs/aura/">Neo4j Aura</a>
               <ul class="project-links">
-                <li><a class="project-link" href="/docs/aura/current/">Neo4j AuraDB</a></li>
+                <li><a class="project-link" href="/docs/aura/auradb/">Neo4j AuraDB</a></li>
+                <li><a class="project-link" href="/docs/aura/aurads/">Neo4j AuraDS</a></li>
               </ul>
             </div>
 


### PR DESCRIPTION
Adds a link to AuraDS in the Docs > Aura menu.