### PR TITLE
Remove component title from meta title if page-ogtitle is specified

### DIFF
--- a/preview-src/tables.adoc
+++ b/preview-src/tables.adoc
@@ -1,5 +1,6 @@
 = Tables
 :nofooter:
+:page-ogtitle: This page uses the page-ogtitle attribute to generate a custom title for SEO meta
 
 .No striping
 // Alternative to stripes attributes is

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -29,7 +29,7 @@
     <meta name="twitter:creator" content="@neo4j" />
     <meta name="twitter:site" content="@neo4j" />
     <meta property="og:type" content="{{{ or page.attributes.postttype 'article' }}}" />
-    <meta property="og:title" content="{{#with (or page.attributes.ogtitle page.title) }}{{{detag this}}}{{/with}} - {{#with page.component.title}}{{{detag this}}}{{/with}}" />
+    <meta property="og:title" content="{{#with (or page.attributes.ogtitle page.title) }}{{{detag this}}}{{/with}}{{#unless page.attributes.ogtitle}} - {{#with page.component.title}}{{{detag this}}}{{/with}}{{/unless}}" />
     <meta property="og:locale" content="{{{ or page.attributes.locale 'en_US' }}}">
     {{#with (or page.attributes.ogimage 'https://dist.neo4j.com/wp-content/uploads/20210423062553/neo4j-social-share-21.png' )}}
     <meta property="og:image" content="{{{this}}}" />


### PR DESCRIPTION
When `:page-ogtitle:` is specified in the document header, we want to use that value as-is for the meta tag.

This update prevents ` - <COMPONENT_TITLE>` from being appended to the meta tag when `:page-ogtitle:` is specified.

To verify, check that the meta tag for `/tables` does not have ` - Project XYZ` added:

`<meta property="og:title" content="This page uses the page-ogtitle attribute to generate a custom title for SEO meta">`
