### PR TITLE
Display multiple page role values with page title

### DIFF
--- a/preview-src/docs-roles.adoc
+++ b/preview-src/docs-roles.adoc
@@ -1,5 +1,6 @@
 = Docs flags
-:page-role: fabric
+:page-role: fabric enterprise-edition alpha test
+:page-theme: docs
 
 [abstract]
 --
@@ -34,6 +35,7 @@ Example 1 content - this example is not deprecated
 Example 2 content - this example is deprecated
 ====
 
+[role=alpha]
 == Alpha content
 
 [.alpha-symbol]

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -49,7 +49,8 @@ body {
 
 .doc > h1.page:first-child {
   font-size: calc(36 / var(--rem-base) * 1rem);
-  margin: 1.5rem 0;
+  margin: 1.5rem 0.5rem 1.5rem 0;
+  display: inline-block;
 }
 
 @media screen and (min-width: 769px) {

--- a/src/css/neo4j-docs.css
+++ b/src/css/neo4j-docs.css
@@ -21,7 +21,6 @@ div.page-roles > span.page-role {
 }
 
 @media screen and (max-width: 1023px) {
-  
   div.page-roles {
     display: block;
   }
@@ -35,8 +34,6 @@ div.page-roles > span.page-role {
   div.page-roles > span.page-role {
     margin-bottom: 0;
   }
-
-
 }
 
 .sect1.alpha h2::after,

--- a/src/css/neo4j-docs.css
+++ b/src/css/neo4j-docs.css
@@ -13,13 +13,38 @@ section.deprecated .title::after {
   margin-left: 10px;
 }
 
-body.alpha article h1::after,
-body.beta article h1::after,
+div.page-roles,
+div.page-roles > span.page-role {
+  display: inline-flex;
+  margin: 0 0 1.5rem;
+  font-size: calc(36 / var(--rem-base) * 1rem);
+}
+
+@media screen and (max-width: 1023px) {
+  
+  div.page-roles {
+    display: block;
+  }
+
+  div.page-roles,
+  div.page-roles > span.page-role::after {
+    margin-left: 0;
+  }
+
+  div.page-roles,
+  div.page-roles > span.page-role {
+    margin-bottom: 0;
+  }
+
+
+}
+
 .sect1.alpha h2::after,
 .sect1.beta h2::after,
 .sect2.alpha h3::after,
 .sect2.beta h3::after,
-body.deprecated article h1::after,
+span.alpha::after,
+span.beta::after,
 body.deprecated article h2::after,
 body.deprecated article h3::after,
 body.deprecated article h4::after,
@@ -32,13 +57,11 @@ section.deprecated .title::after,
 span.deprecated::after,
 .deprecated > .title::after,
 section.enterprise-edition .title::after,
-body.enterprise-edition article h1::after,
 div.enterprise-edition h2::after,
 div.enterprise-edition h3::after,
 div.enterprise-edition h4::after,
 p.enterprise-edition::before,
 span.enterprise-edition::after,
-body.fabric article h1::after,
 body.fabric article h2::after,
 body.fabric article h3::after,
 body.fabric article h4::after,
@@ -62,7 +85,6 @@ span.fabric::after {
   margin-left: 8px;
 }
 
-body.deprecated article h1::after,
 body.deprecated article h2::after,
 body.deprecated article h3::after,
 body.deprecated article h4::after,
@@ -79,7 +101,6 @@ span.deprecated::after {
   border-color: var(--deprecation-color);
 }
 
-body.enterprise-edition article h1::after,
 div.enterprise-edition h2::after,
 div.enterprise-edition h3::after,
 div.enterprise-edition h4::after,
@@ -91,7 +112,6 @@ span.enterprise-edition::after {
   border-color: var(--enterprise-edition-color);
 }
 
-body.fabric article h1::after,
 div.fabric h2::after,
 div.fabric h3::after,
 div.fabric h4::after,
@@ -152,24 +172,24 @@ span.fabric::after {
 
 /* GDS */
 
-body.alpha article h1::after,
-body.beta article h1::after,
 .sect1.alpha h2::after,
 .sect1.beta h2::after,
 .sect2.alpha h3::after,
-.sect2.beta h3::after {
+.sect2.beta h3::after,
+span.alpha::after,
+span.beta::after {
   color: var(--alpha-beta-color);
 }
 
-body.alpha article h1::after,
 .sect1.alpha h2::after,
-.sect2.alpha h3::after {
+.sect2.alpha h3::after,
+span.alpha::after {
   content: "alpha";
 }
 
-body.beta article h1::after,
 .sect1.beta h2::after,
-.sect2.beta h3::after {
+.sect2.beta h3::after,
+span.beta::after {
   content: "beta";
 }
 

--- a/src/helpers/split-string.js
+++ b/src/helpers/split-string.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (value, joiner) => value.split(joiner)

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -12,6 +12,15 @@ If you typed the URL of this page manually, please double check that you entered
 {{#with page.title}}
 <h1 class="page">{{{this}}}</h1>
 {{/with}}
+{{#with (or page.attributes.role page.role)}}
+<div class="page-roles is-before-toc">
+  {{#each (split-string this ' ')}}
+    <span class="page-role {{{this}}}"></span>
+  {{/each}}
+</div>
+{{/with}}
+
+{{!-- <span class="{{#with asciidoc.attributes.role}} {{{this}}}{{/with}}"></span> --}}
 {{{page.contents}}}
 {{#if (ne page.attributes.certificate undefined)}}
   <div id="_get_certificate" class="sect1 columns medium-12">


### PR DESCRIPTION
Requested by GDS

To verify, check that the [Docs roles page](https://deploy-preview-113--neo4j-docs-ui.netlify.app/docs-roles.html) lists multiple roles by the page title.
For smaller page widths, the roles are displayed below the title, above the in-page toc.