### PR TITLE
Comment out the Developer Guides to remove them from the UI drop downs

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -89,7 +89,7 @@
     <div id="topbar-nav" class="navbar-menu">
       <div class="navbar-end">
 
-        <div class="navbar-item has-dropdown is-hoverable developer">
+        {{!-- <div class="navbar-item has-dropdown is-hoverable developer">
           <a class="navbar-link" href="/developer/">Developer Guides</a>
           <div class="navbar-dropdown">
             <div class="navbar-item project">
@@ -124,7 +124,6 @@
             <div class="navbar-item project">
               <a class="project-name" href="/developer/language-guides/">Administration and Deployment</a>
               <ul class="project-links">
-                {{!-- <li><a class="project-link" href="/developer/aura-cloud-dbaas/">Neo4j Aura DBaaS</a></li> --}}
                 <li><a class="project-link" href="/developer/graph-apps/">Graph Apps</a></li>
                 <li><a class="project-link" href="/developer/in-production/">Neo4j Administration</a></li>
                 <li><a class="project-link" href="/developer/guide-cloud-deployment/">Neo4j in the Cloud</a></li>
@@ -140,11 +139,9 @@
             <div class="navbar-item project">
               <a class="project-name" href="/graphgists/">GraphGists</a>
             </div>
-
-            {{!-- <a class="navbar-item" href="/developer/resources/">Documentation &amp; Resources</a> --}}
-            {{!-- <a class="navbar-item" href="/developer/contribute/">Contributing to Neo4j</a> --}}
           </div>
-        </div>
+        </div> --}}
+
         <div class="navbar-item has-dropdown is-hoverable docs">
           <a class="navbar-link" href="/docs/">Docs</a>
           <div class="navbar-dropdown">


### PR DESCRIPTION
The PR will remove the *Developer Guides* drop down menu, which appears at the top of each page within docs.

The pages themselves will still be available, but we'll be adding an admonition to the top of each page which says that this page is no longer being maintained, with signposting to the new location within the docs.