### PR TITLE
Swap order of language name and block title in code examples (language first)

### DIFF
--- a/src/css/code.css
+++ b/src/css/code.css
@@ -21,11 +21,12 @@
 .doc .code-header .code-title {
   color: var(--color-grey-500);
   padding-right: 0.5em;
+  flex-grow: 1000;
 }
 
 .doc .code-header .code-language {
   flex-grow: 1;
-  padding: 0.6rem 0;
+  padding: 0.6rem 0.6rem 0 0;
 }
 
 .doc .code-header .btn,

--- a/src/css/code.css
+++ b/src/css/code.css
@@ -18,14 +18,18 @@
   font-weight: var(--body-font-weight-bold);
 }
 
+.doc .code-header .code-spacer {
+  flex-grow: 1;
+}
+
 .doc .code-header .code-title {
   color: var(--color-grey-500);
   padding-right: 0.5em;
-  flex-grow: 1000;
+  flex-grow: 1;
 }
 
 .doc .code-header .code-language {
-  flex-grow: 1;
+  flex-grow: 0;
   padding: 0.6rem 0.6rem 0 0;
 }
 

--- a/src/js/06-code.js
+++ b/src/js/06-code.js
@@ -120,6 +120,17 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     var children = [languageDiv]
 
+    var originalTitle = div.parentNode.querySelector('.title')
+    if (originalTitle) {
+      var titleDiv = document.createElement('div')
+      titleDiv.className = 'code-title'
+      titleDiv.innerHTML = originalTitle.innerHTML
+
+      originalTitle.style.display = 'none'
+
+      children.push(titleDiv)
+    }
+
     if (addCopyButton) {
       var copyButton = createElement('button', 'btn btn-copy', [document.createTextNode('Copy to Clipboard')])
       copyButton.addEventListener('click', function (e) {
@@ -167,17 +178,6 @@ document.addEventListener('DOMContentLoaded', function () {
       })
 
       children.push(runButton)
-    }
-
-    var originalTitle = div.parentNode.querySelector('.title')
-    if (originalTitle) {
-      var titleDiv = document.createElement('div')
-      titleDiv.className = 'code-title'
-      titleDiv.innerHTML = originalTitle.innerHTML
-
-      originalTitle.style.display = 'none'
-
-      children.unshift(titleDiv)
     }
 
     var header = createElement('div', 'code-header', children)

--- a/src/js/06-code.js
+++ b/src/js/06-code.js
@@ -131,6 +131,8 @@ document.addEventListener('DOMContentLoaded', function () {
       children.push(titleDiv)
     }
 
+    children.push(createElement('div', 'code-spacer'))
+
     if (addCopyButton) {
       var copyButton = createElement('button', 'btn btn-copy', [document.createTextNode('Copy to Clipboard')])
       copyButton.addEventListener('click', function (e) {


### PR DESCRIPTION
This is the current situation:
![Screenshot from 2022-11-09 08-20-53](https://user-images.githubusercontent.com/114478074/200764684-e0bf8177-bb6f-428b-bb5c-2418310107d7.png)
![Screenshot from 2022-11-09 08-21-02](https://user-images.githubusercontent.com/114478074/200764688-10924f69-fff9-4c7a-88cd-bb544e7ef418.png)

And this is the effect of this PR:
![Screenshot from 2022-11-09 08-19-42](https://user-images.githubusercontent.com/114478074/200764495-328c7c2a-57cc-4c70-afc0-1dffa880ddc4.png)
![Screenshot from 2022-11-09 08-19-56](https://user-images.githubusercontent.com/114478074/200764497-f429517b-e4b2-4163-b258-4b63f0cd4781.png)

----

I have altered the way in which the divs in the code block are created, so that `languageDiv` comes now after `titleDiv`. 

A naive solution where `flex-grow: 1` is only given to `.code-title` is not enough as it breaks when there the example block has no title (the second one here)
![Screenshot from 2022-11-09 08-26-43](https://user-images.githubusercontent.com/114478074/200765683-3874c28e-081a-4fb8-9f4e-987769b3279e.png)
that's why I have `flex-grow` on both elements, one at 1 and one at 1000.