### PR TITLE
Hide page title on labs landing page

### DIFF
--- a/src/css/landing.css
+++ b/src/css/landing.css
@@ -104,6 +104,13 @@ section.hero p {
 }
 
 /**
+ * Hide page title since we are already using a hero title
+ */
+body.landing.labs h1.page {
+  display: none;
+}
+
+/**
  * Landing Preamble - button and angled borders
  */
 body.landing .ulist.buttons {


### PR DESCRIPTION
Since we are already using a hero title

**Before**
![image](https://user-images.githubusercontent.com/333276/201610530-e6bb5146-dcb6-48ba-b638-32ea161e389d.png)

**After**
![image](https://user-images.githubusercontent.com/333276/201610631-602f9855-5492-4cb4-863c-adbcf1c4b702.png)


