### PR TITLE
Add distance between embedded (mobile) toc and content

### DIFF
--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -129,3 +129,9 @@
 .toc-sidebar .toc-menu {
   margin-bottom: 4rem;
 }
+
+aside.toc.embedded {
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 0.5rem;
+}


### PR DESCRIPTION
Currently, on narrow screens the table of contents gets rendered at the top and without any visible separation from the page content:

![old](https://user-images.githubusercontent.com/114478074/203347614-a2a765b4-ef6b-46f2-955c-c4a450e23ccd.png)

With this PR, the design looks like this

![new](https://user-images.githubusercontent.com/114478074/203347608-cf1269a5-670b-4b02-965c-35638f8e9747.png)
