### PR TITLE
Rename drivers/apis section to "Create applications" in navigation

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -196,11 +196,11 @@
             <div class="navbar-item project">
               <span class="project-name" href="/docs/drivers-apis">Create applications</span>
               <ul class="project-links">
+                <li><a href="{{#with (docs-driver-manual-url page 'python-manual')}}{{{this}}}{{/with}}" class="project-link">Python Driver</a></li>
                 <li><a href="{{#with (docs-driver-manual-url page 'go-manual')}}{{{this}}}{{/with}}" class="project-link">Go Driver</a></li>
                 <li><a href="{{#with (docs-driver-manual-url page 'java-manual')}}{{{this}}}{{/with}}" class="project-link">Java Driver</a></li>
                 <li><a href="{{#with (docs-driver-manual-url page 'javascript-manual')}}{{{this}}}{{/with}}" class="project-link">JavaScript Driver</a></li>
                 <li><a href="{{#with (docs-driver-manual-url page 'dotnet-manual')}}{{{this}}}{{/with}}" class="project-link">.Net Driver</a></li>
-                <li><a href="{{#with (docs-driver-manual-url page 'python-manual')}}{{{this}}}{{/with}}" class="project-link">Python Driver</a></li>
                 <li><a href="/docs/graphql-manual/current/" class="project-link">Neo4j GraphQL Library</a></li>
                 <li><a href="/docs/http-api/current/" class="project-link">HTTP API</a></li>
                 <li><a href="/docs/ogm-manual/current/" class="project-link">OGM Library</a></li>

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -194,7 +194,7 @@
             </div>
 
             <div class="navbar-item project">
-              <span class="project-name" href="/docs/drivers-apis">Neo4j Drivers and APIs</span>
+              <span class="project-name" href="/docs/drivers-apis">Create applications</span>
               <ul class="project-links">
                 <li><a href="{{#with (docs-driver-manual-url page 'go-manual')}}{{{this}}}{{/with}}" class="project-link">Go Driver</a></li>
                 <li><a href="{{#with (docs-driver-manual-url page 'java-manual')}}{{{this}}}{{/with}}" class="project-link">Java Driver</a></li>


### PR DESCRIPTION
I believe `Drivers and APIs` is meaningful internally, but doesn't give away too much information to newcomers. Eventually, I guess everybody realizes that if you are looking for info on how to use Neo4j with Python, you should click on `Python` in that list, but this just creates an extra second of confusion. The word `Driver` is not commonly used in software to refer to these sort of libraries, so I would take it away at least from the navigation menu.

I suggest renaming it to `Create applications`. We could also go for `Create applications with`, implying that each element of the list completes the title, but I don't quite like it. Another, **possibly my favorite**, that comes to mind is `Libraries and APIs` (though I imagine the drivers team might not be happy with this). I am not a fan of the wording `Connect your application` (as we have in tiles) because it suggests that you already have an application, and you simply _connect_ it to Neo4j, whereas in reality most people will need to develop largely from scratch. I am happy to hear other ideas :) 

---

Merge after https://github.com/neo-technology/docs-home/pull/66
