### PR TITLE
Restore original height after copy to clipboard button is clicked

### DIFF
--- a/src/js/06-code.js
+++ b/src/js/06-code.js
@@ -149,6 +149,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         setTimeout(function () {
           button.innerHTML = text
+          button.style.width = ''
           button.classList.remove('btn-success')
         }, 1000)
       })


### PR DESCRIPTION
Fix #132, result:

![Peek 2022-11-30 06-47](https://user-images.githubusercontent.com/114478074/204717894-24489b71-1e73-4de8-9821-5184fcc94d10.gif)

(it makes sense to set the width a few lines earlier, or the `Success` button gets shrunk).