### PR TITLE
Section roles fix

### DIFF
--- a/preview-src/docs-roles.adoc
+++ b/preview-src/docs-roles.adoc
@@ -1,7 +1,7 @@
 = Docs flags
-:page-role: enterprise-edition not-on-aura aura-db-enterprise test
+:page-role: enterprise-edition not-on-aura
 :page-theme: docs
-:page-labels: fabric enterprise-edition alpha test
+// :page-labels: fabric enterprise-edition alpha test
 
 [abstract]
 --

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -47,14 +47,15 @@ body {
   color: var(--color-grey-600);
 }
 
-.doc > h1.page:first-child {
+.doc > .sect-header > h1.page:first-child {
   font-size: calc(36 / var(--rem-base) * 1rem);
   margin: 1.5rem 0.5rem 1.5rem 0;
-  display: inline-block;
+  display: flex;
+  flex-grow: 1;
 }
 
 @media screen and (min-width: 769px) {
-  .doc > h1.page:first-child {
+  .doc > .sect-header > h1.page:first-child {
     margin-top: 2.5rem;
   }
 }
@@ -117,7 +118,7 @@ body {
 }
 
 @media screen and (max-width: 620px) {
-  .doc > h1.page:first-child {
+  .doc > .sect-header > h1.page:first-child {
     font-size: 1.4rem;
     font-weight: 600;
   }

--- a/src/css/neo4j-docs.css
+++ b/src/css/neo4j-docs.css
@@ -47,7 +47,6 @@ div.roles > span.role {
 }
 
 @media screen and (max-width: 1023px) {
-
   div.roles,
   div.roles > span.role::after {
     margin-left: 0;
@@ -147,7 +146,6 @@ span.fabric::after {
 
 .sect1 > .sect-header {
   border-bottom: 1px solid var(--section-divider-color);
-  
   margin-bottom: 1.5rem;
   padding-bottom: 0.5rem;
 }

--- a/src/css/neo4j-docs.css
+++ b/src/css/neo4j-docs.css
@@ -41,14 +41,12 @@ section.deprecated .title::after {
 div.roles,
 div.roles > span.role {
   display: inline-flex;
-  margin: 0 0 1.5rem;
+  gap: 8px;
   font-size: calc(36 / var(--rem-base) * 1rem);
+  line-height: 1.3;
 }
 
 @media screen and (max-width: 1023px) {
-  div.roles {
-    display: block;
-  }
 
   div.roles,
   div.roles > span.role::after {
@@ -117,7 +115,7 @@ span.fabric::after {
   border-width: 1px;
   border-radius: 6px;
   bottom: 2px;
-  margin-left: 8px;
+  /* margin-left: 8px; */
 }
 
 .sect1.show-roles h2::after,
@@ -128,17 +126,39 @@ span.fabric::after {
 
 .sect1.show-roles h2,
 .sect2.show-roles h3,
-.sect3.show-roles h4 {
-  display: inline-block;
+.sect2.show-roles h4 {
+  display: inline-flex;
+  flex-grow: 1;
+  padding-top: var(--body-font-size);
 }
 
 .sect2.show-roles div.roles,
 .sect2.show-roles div.roles > span.role {
   font-size: 1rem;
+  margin-bottom: 0;
 }
 
-.sect1.show-roles h2 {
+.sect-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  margin-bottom: 1.5rem;
+}
+
+.sect1 > .sect-header {
+  border-bottom: 1px solid var(--section-divider-color);
+  
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.sect1 div.roles > span.role {
+  margin: 0;
+}
+
+.doc .sect-header h2 {
   border-bottom: none;
+  margin-bottom: 0;
 }
 
 body.deprecated article h2::after,
@@ -155,6 +175,7 @@ span.deprecated::after {
   content: "deprecated";
   color: var(--deprecation-color);
   border-color: var(--deprecation-color);
+  margin-left: 8px;
 }
 
 div.not-on-aura h2::after,

--- a/src/js/60-docs-roles.js
+++ b/src/js/60-docs-roles.js
@@ -23,22 +23,16 @@ document.addEventListener('DOMContentLoaded', function () {
         // // let span = createElement('span', `role ${role}`)
         // // console.log(span.outerHTML)
 
-        
-
         // let elem = document.querySelector(`span.${role}`)
 
         // // let elem = getComputedStyle(span, ':after').content;
         // span.textContent = getComputedStyle(elem, ':after').getPropertyValue('content').replace(/"/g, '')
         // console.log(span.textContent)
         // insert.append(span)
-
       })
       newRolesDiv.append(insert)
-      
-      
     }
     sectionDiv.prepend(newRolesDiv)
     sectionDiv.classList.add('show-roles')
-
   })
 })

--- a/src/js/60-docs-roles.js
+++ b/src/js/60-docs-roles.js
@@ -1,19 +1,44 @@
 import { createElement } from './modules/dom'
 
 document.addEventListener('DOMContentLoaded', function () {
-  const roleDivs = document.querySelectorAll('body.docs div[class^="sect"]:not(.sectionbody)')
-  roleDivs.forEach(function (roleDiv) {
-    var roles = roleDiv.classList
-    roles = [...roles].filter(function (c) {
+  const sectionDivs = document.querySelectorAll('body.docs div[class^="sect"]:not(.sectionbody,.sect-header)')
+  sectionDivs.forEach(function (sectionDiv) {
+    var roles = sectionDiv.classList
+    roles = [...roles].sort().filter(function (c) {
       return (!c.startsWith('sect'))
     })
-    if (roles) {
+
+    var newRolesDiv = createElement('div', 'sect-header')
+    var head = sectionDiv.querySelector('h2,h3,h4,h5,h6')
+    // console.log(head.tagName)
+    newRolesDiv.append(head)
+
+    if (roles.length > 0) {
       var insert = createElement('div', 'roles')
       roles.forEach(function (role) {
-        insert.append(createElement('span', 'role ' + role))
+        insert.append(createElement('span', `role ${role}`))
+
+        // const span = createElement('span', `label label--${role}`)
+
+        // // let span = createElement('span', `role ${role}`)
+        // // console.log(span.outerHTML)
+
+        
+
+        // let elem = document.querySelector(`span.${role}`)
+
+        // // let elem = getComputedStyle(span, ':after').content;
+        // span.textContent = getComputedStyle(elem, ':after').getPropertyValue('content').replace(/"/g, '')
+        // console.log(span.textContent)
+        // insert.append(span)
+
       })
-      roleDiv.firstElementChild.after(insert)
-      roleDiv.classList.add('show-roles')
+      newRolesDiv.append(insert)
+      
+      
     }
+    sectionDiv.prepend(newRolesDiv)
+    sectionDiv.classList.add('show-roles')
+
   })
 })

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -9,6 +9,7 @@
 If you typed the URL of this page manually, please double check that you entered the address correctly.</p>
 </div>
 {{else}}
+<div class="sect-header">
 {{#with page.title}}
 <h1 class="page">{{{this}}}</h1>
 {{/with}}
@@ -19,6 +20,7 @@ If you typed the URL of this page manually, please double check that you entered
   {{/each}}
 </div>
 {{/with}}
+</div>
 
 {{#with (or page.attributes.labels page.labels)}}
 <div class="paragraph labels">


### PR DESCRIPTION
Improves the appearance of roles when displayed against headers, by right-aligning them, as we do for the cheat sheet.
I'd like in future for us to remove the distinction, at least in appearance, between roles and labels, which are performing largely the same function.

