### PR TITLE
Prevent content overlap in source block

### DIFF
--- a/src/css/code.css
+++ b/src/css/code.css
@@ -47,14 +47,6 @@
   padding: 0.25rem 0;
 }
 
-.doc pre {
-  display: flex;
-}
-
-.doc pre .code-inset {
-  display: flex;
-}
-
 .doc .listingblock .code-inset .btn {
   border: 0 none;
   padding: 0.6rem 0;
@@ -103,14 +95,15 @@
 
 .doc .listingblock .code-inset {
   border-top-right-radius: 0.5rem;
-  background: var(--pre-background);
-  color: var(--color-grey-700);
+  /* background: var(--pre-background); */
+  color: var(--color-grey-600);
   font-size: calc(12.5 / var(--rem-base) * 1rem);
-  position: relative;
-  float: right;
-  padding: 1rem 0.5rem;
-  margin-left: -2rem;
+  position: absolute;
+  /* float: right; */
+  padding: 0.25rem 0.5rem;
+  /* margin-left: -2rem; */
   z-index: 1;
+  right: 0;
 }
 
 .doc .code-inset .copy-success.hidden {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -711,7 +711,7 @@ body {
   overflow-x: auto;
   width: 100%;
   height: 100%;
-  padding: 1rem 0.5rem;
+  padding: 1.5rem 0.5rem;
   border-bottom-left-radius: 0.5rem;
   border-bottom-right-radius: 0.5rem;
 }
@@ -729,7 +729,7 @@ body {
 .doc .listingblock .code-inset[data-lang]::before {
   /* opacity: 0.9; */
   content: attr(data-lang);
-  display: none;
+  /* display: none; */
   /* color: var(--pre-annotation-font-color); */
   font-size: calc(12.5 / var(--rem-base) * 1rem);
   font-family: var(--monospace-font-family);
@@ -737,12 +737,16 @@ body {
   line-height: 1;
   text-transform: uppercase;
   position: absolute;
-  top: 1.25rem;
+  top: 0.5rem;
   right: 1.5rem;
   margin-right: 0.25rem;
 }
 
-.doc .listingblock:hover .code-inset[data-lang]::before {
+.doc .listingblock .code-inset {
+  display: none;
+}
+
+.doc .listingblock:hover .code-inset {
   display: block;
 }
 


### PR DESCRIPTION
Fixes an issue where a long first line of content in a source block would clash with the language and copy button on hover.