### PR TITLE
Cheat sheet updates for Aura and Neo4j

### DIFF
--- a/preview-src/cheat-sheet.adoc
+++ b/preview-src/cheat-sheet.adoc
@@ -6,10 +6,9 @@
 :page-no-toolbar: true
 
 
-[.configuration]
 == How the cheat sheet works
 
-
+// this has no product, which means it matches all products
 === Example structure
 
 =====
@@ -101,6 +100,65 @@ Text describing the example. This example has no role, and therefore no labels. 
 This example only applies to Neo4j Enterprise Edition and is marked with the `[.neo4j-ee]` role.
 ====
 
+
+[.read]
+== Read queries
+
+
+=== Read queries subsection
+
+
+====
+[source, cypher, role=noheader]
+----
+<CYPHER EXAMPLE>
+----
+
+[.description]
+Text describing the example. This example has no role, and therefore no labels. It is displayed in all views.
+====
+
+[.neo4j-ee]
+====
+[source, cypher, role=noheader]
+----
+<CYPHER EXAMPLE>
+----
+
+[.description]
+This example only applies to Neo4j Enterprise Edition and is marked with the `[.neo4j-ee]` role.
+====
+
+
+== Write queries
+
+
+=== Write queries subsection
+
+
+====
+[source, cypher, role=noheader]
+----
+<CYPHER EXAMPLE>
+----
+
+[.description]
+Text describing the example. This example has no role, and therefore no labels. It is displayed in all views.
+====
+
+
+[.neo4j-ee]
+====
+[source, cypher, role=noheader]
+----
+<CYPHER EXAMPLE>
+----
+
+[.description]
+This example only applies to Neo4j Enterprise Edition and is marked with the `[.neo4j-ee]` role.
+====
+
+
 === link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/match/[Title with link^]
 
 
@@ -125,7 +183,7 @@ Therefore it is formatted as an open block
 ====
 
 
-[.neo4j-ee.aura-dse]
+[.neo4j-ee]
 ====
 [source, cypher, role=noheader]
 ----
@@ -134,11 +192,39 @@ RETURN n AS node
 ----
 
 [.description]
-Displayed for Neo4j Enterprise Edition and AuraDS Enterprise
+Displayed for Neo4j Enterprise Edition
+
+[.extra]
+--
+Some additional content.
+Can be any arbitrary asciidoc blocks and elements.
+
+|===
+| Name | Description
+
+| Asciidoctor
+| *Awesome* way to write documentation
+
+| Micronaut
+| Low resource usage and fast startup micro services
+|===
+--
 ====
 
 
-[.deprecated]
+[.neo4j-ee]
+====
+[source, cypher, role=noheader]
+----
+MATCH (n)
+RETURN n AS node
+----
+
+[.description]
+Displayed for Neo4j Enterprise Edition
+====
+
+
 ====
 [source, cypher, role=noheader]
 ----
@@ -147,7 +233,7 @@ RETURN n.name AS name
 ----
 
 [.description]
-This example is displayed in all views, and is deprecated.
+This example is displayed in all views.
 ====
 
 
@@ -178,9 +264,11 @@ This example is displayed for both AuraDB Free and AuraDB Enterprise.
 ====
 
 
-[.neo4j-ce.neo4j-ee]
+
 == Not on Aura
 
+
+[.neo4j-ce.neo4j-ee]
 === Not on Aura examples
 
 ====
@@ -263,4 +351,125 @@ That's a lot of labels.
 
 [.description]
 Deprecated cypher example.
+====
+
+
+== Functions
+
+
+=== Temporal functions
+
+
+====
+[source, cypher, role=noheader]
+----
+date('2018-04-05')
+----
+
+[.description]
+Returns a date parsed from a string.
+====
+
+
+====
+[source, cypher, role=noheader]
+----
+localtime('12:45:30.25')
+----
+
+[.description]
+Returns a time with no time zone.
+====
+
+
+====
+[source, cypher, role=noheader]
+----
+time('12:45:30.25+01:00')
+----
+
+[.description]
+Returns a time in a specified time zone.
+====
+
+
+====
+[source, cypher, role=noheader]
+----
+localdatetime('2018-04-05T12:34:00')
+----
+
+[.description]
+Returns a datetime with no time zone.
+====
+
+
+====
+[source, cypher, role=noheader]
+----
+datetime('2018-04-05T12:34:00[Europe/Berlin]')
+----
+
+[.description]
+Returns a datetime in the specified time zone.
+====
+
+
+====
+[source, cypher, role=noheader]
+----
+datetime({epochMillis: 3360000})
+----
+
+[.description]
+Transforms 3360000 as a UNIX Epoch time into a normal datetime.
+====
+
+
+[.neo4j-ce.aura-dbe]
+====
+[source, cypher, role=noheader]
+----
+date({year: $year, month: $month, day: $day})
+----
+
+[.description]
+All of the temporal functions can also be called with a map of named components.
+This example returns a date from year, month and day components.
+Each function supports a different set of possible components.
+====
+
+
+====
+[source, cypher, role=noheader]
+----
+datetime({date: $date, time: $time})
+----
+
+[.description]
+Temporal types can be created by combining other types.
+This example creates a datetime from a date and a time.
+====
+
+
+====
+[source, cypher, role=noheader]
+----
+date({date: $datetime, day: 5})
+----
+
+[.description]
+Temporal types can be created by selecting from more complex types, as well as overriding individual components. This example creates a date by selecting from a datetime, as well as overriding the day component.
+====
+
+
+====
+[source, cypher, role=noheader]
+----
+WITH date('2018-04-05') AS d
+RETURN d.year, d.month, d.day, d.week, d.dayOfWeek
+----
+
+[.description]
+Accessors allow extracting components of temporal types.
 ====

--- a/preview-src/cheat-sheet.adoc
+++ b/preview-src/cheat-sheet.adoc
@@ -28,6 +28,11 @@ Description
 
 More description
 --
+
+[.extra] <6>
+--
+Additional content, to be used sparingly because this is a cheat sheet or quick reference, not a full Cypher reference manual.
+--
 ====
 -----
 
@@ -38,6 +43,7 @@ More description
 <3> Add an optional block for a Cypher example, specifying `[source, cypher,`role=noheader`].
 <4> Add a required description block.
 <5> If the description consists of more than one paragraph of text, use an open block.
+<6> If you need to, you can add `extra` content, which is displayed below the example code and description.
 --
 =====
 
@@ -49,26 +55,28 @@ More description
 -----
 asciidoc:
   attributes:
-    page-cheatsheets: <1>
-      - name: 'Neo4j Enterprise Edition' <2>
-        label: 'Enterprise Edition' <3>
-        class: 'neo4j-ee' <4>
-        default: true <5>
+    page-cheatsheet-product: Neo4j <1>
+    page-cheatsheet-products: <2>
+      - name: 'Neo4j Enterprise Edition' <3>
+        label: 'Enterprise Edition' <4>
+        class: 'neo4j-ee' <5>
+        default: true <6>
       - name: 'Neo4j Community Edition'
         class: 'neo4j-ce'
       - name: 'Deprecated'
         class: 'deprecated'
-        label-only: true <6>
+        label-only: true <7>
 -----
 
 [.description]
 --
-<1> Add a `page-cheatsheets` section to the playbook to define the different views that a user can choose from. In this example we've added two views: Neo4j Enterprise Edition and Neo4j Community Edition.
-<2> Add a name for each view. This text is displayed in the dropdown that you use to select which Cheat Sheet you want to view. 
-<3> [Optional] Add label text. When an example is not applicable in all views, a label is displayed to indicate which views it applies to. If no `label` value is specified, the value of `name` is used. 
-<4> Specify a class for each view. This is used to add a role to the example block. For example, the class `neo4j-ee` is specified by `[.neo4j-ee]`.
-<5> Specify a default view. This is the view that is displayed when the page is loaded.
-<6> If you want to display a label for some entries without that label appearing in the dropdown, you can use the `label-only` attribute. In this example, entries that have the `[.deprecated]` role will have the `Deprecated` label displayed, but 'Deprecated' is not an option you can select from the dropdown. In this preview build, both `Configuration` and `Deprecated` have been added as `label-only` views.
+<1> Add a product name to displayed before `Version` in the version selector. The default value is `Product`.
+<2> Add a `page-cheatsheet-products` section to the playbook to define the different views that a user can choose from. In this example we've added two views: Neo4j Enterprise Edition and Neo4j Community Edition.
+<3> Add a name for each view. This text is displayed in the dropdown that you use to select which Cheat Sheet you want to view. 
+<4> [Optional] Add label text. When an example is not applicable in all views, a label is displayed to indicate which views it applies to. If no `label` value is specified, the value of `name` is used. 
+<5> Specify a class for each view. This is used to add a role to the example block. For example, the class `neo4j-ee` is specified by `[.neo4j-ee]`.
+<6> Specify a default view. This is the view that is displayed when the page is loaded.
+<7> If you want to display a label for some entries without that label appearing in the dropdown, you can use the `label-only` attribute. In this example, entries that have the `[.deprecated]` role will have the `Deprecated` label displayed, but 'Deprecated' is not an option you can select from the dropdown. In this preview build, both `Configuration` and `Deprecated` have been added as `label-only` views.
 --
 =====
 
@@ -205,8 +213,8 @@ Can be any arbitrary asciidoc blocks and elements.
 | Asciidoctor
 | *Awesome* way to write documentation
 
-| Micronaut
-| Low resource usage and fast startup micro services
+| Neo4j
+| Graphy
 |===
 --
 ====

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -234,29 +234,47 @@ page:
       urlType: internal
   # additional page attributes indexed by page-slug
     pages-data:
-      cheatsheets: &cheatsheets 
+      cheatsheet-products: &cheatsheet-products 
         - name: 'Neo4j Community Edition'
           class: 'neo4j-ce'
         - name: 'Neo4j Enterprise Edition'
           class: 'neo4j-ee'
-          default: true
+          # default: true
         - name: 'AuraDB Free'
           class: 'aura-dbf'
-        - name: 'AuraDB Professional'
-          class: 'aura-dbp'
-        - name: 'AuraDB Enterprise'
-          class: 'aura-dbe'
+        # - name: 'AuraDB Professional'
+        #   class: 'aura-dbp'
+        # - name: 'AuraDB Enterprise'
+        #   class: 'aura-dbe'
           # default: true
-        - name: 'AuraDS Professional'
-          class: 'aura-dsp'
-        - name: 'AuraDS Enterprise'
-          class: 'aura-dse'
+        # - name: 'AuraDS Professional'
+        #   class: 'aura-dsp'
+        # - name: 'AuraDS Enterprise'
+        #   class: 'aura-dse'
+      cheatsheet-labels: &cheatsheet-labels
         - name: 'Deprecated'
           class: 'deprecated'
           label-only: true
         - name: 'Configuration'
           class: 'configuration'
           label-only: true
+      cheatsheet-categories: &cheatsheet-categories
+        - name: 'Read'
+          class: 'read'
+          # default: true
+        - name: 'Write'
+          class: 'write'
+        - name: 'General'
+          class: 'general'
+        - name: 'Functions'
+          class: 'functions'
+        # - name: 'Configuration'
+        #   class: 'configuration'
+        #   label-only: true
+        # - name: 'Deprecated'
+          # class: 'deprecated'
+          # label-only: true
+      cheatsheet-personas: &cheatsheet-personas
       industries: &industries
         - imageUrl: 'https://graphgist-portal-production.s3.amazonaws.com/graph_starter/images/sources/398/dbb/3b-/medium/noun_129319.png'
           name: 'Sports and Recreation'
@@ -323,7 +341,11 @@ page:
       usecases: *usecases
       industries: *industries
     cheat-sheet:
-      cheatsheets: *cheatsheets
+      cheatsheet-products: *cheatsheet-products
+      # cheatsheet-categories: *cheatsheet-categories
+      # cheatsheet-personas: *cheatsheet-personas
+      # cheatsheet-labels: *cheatsheet-labels
+      cheatsheet-product: 'Neo4j'
       show-labels: true
 
     graphgists:

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -239,18 +239,17 @@ page:
           class: 'neo4j-ce'
         - name: 'Neo4j Enterprise Edition'
           class: 'neo4j-ee'
-          # default: true
         - name: 'AuraDB Free'
           class: 'aura-dbf'
-        # - name: 'AuraDB Professional'
-        #   class: 'aura-dbp'
-        # - name: 'AuraDB Enterprise'
-        #   class: 'aura-dbe'
-          # default: true
-        # - name: 'AuraDS Professional'
-        #   class: 'aura-dsp'
-        # - name: 'AuraDS Enterprise'
-        #   class: 'aura-dse'
+        - name: 'AuraDB Professional'
+          class: 'aura-dbp'
+        - name: 'AuraDB Enterprise'
+          class: 'aura-dbe'
+          default: true
+        - name: 'AuraDS Professional'
+          class: 'aura-dsp'
+        - name: 'AuraDS Enterprise'
+          class: 'aura-dse'
       cheatsheet-labels: &cheatsheet-labels
         - name: 'Deprecated'
           class: 'deprecated'

--- a/src/css/cheat-sheet.css
+++ b/src/css/cheat-sheet.css
@@ -9,9 +9,13 @@
   }
 }
 
+body.cheat-sheet {
+  opacity: 0;
+}
+
 body.cheat-sheet .article > .content {
   background: var(--pre-background);
-  padding-top: calc(var(--toolbar-height) / 2);
+  padding-top: 0;
 }
 
 /*  navbar */
@@ -139,8 +143,17 @@ body.cheat-sheet .navbar-link a.external::after {
   background-position: center;
 }
 
+body.cheat-sheet .selectors {
+  display: flex;
+  flex-direction: column;
+}
+
+body.cheat-sheet .selectors div[data-selector-type="labels"] {
+  display: none;
+}
+
 body.cheat-sheet .dropdown .dropdown-label {
-  /* display: inline; */
+  display: inline;
   padding: 0.5rem 2rem 0.5rem 0.5rem;
 }
 
@@ -148,23 +161,24 @@ body.cheat-sheet .nav-panel-versions {
   height: auto;
   padding: 0;
   display: flex;
-  border-left: 1px solid var(--color-grey-300);
 }
 
 body.cheat-sheet .nav-panel-versions .dropdown {
-  display: flex;
+  /* display: flex; */
 }
 
-body.cheat-sheet .nav-panel-types .dropdown {
+body.cheat-sheet .selectors .dropdown {
   width: 100%;
+  display: flex;
+  align-items: center;
 }
 
 body.cheat-sheet .nav-panel-types .dropdown .dropdown-label,
 body.cheat-sheet .nav-panel-versions .dropdown .dropdown-label {
-  display: block;
+  display: flex;
   white-space: nowrap;
   /* width: 300px; */
-  padding: 0.5rem 1rem;
+  /* padding: 0.5rem 1.5rem; */
 }
 
 body.cheat-sheet .nav-panel-versions .dropdown .dropdown-styles {
@@ -172,11 +186,19 @@ body.cheat-sheet .nav-panel-versions .dropdown .dropdown-styles {
   display: inline-block;
 }
 
-body.cheat-sheet .nav-panel-types .dropdown .dropdown-styles {
+body.cheat-sheet .selectors > div {
+  align-items: center;
+  display: flex;
+  /* flex-wrap: wrap; */
+  box-shadow: none;
+  margin: 0.25rem;
+  /* padding: 0.25rem 0; */
+}
+
+body.cheat-sheet .selectors .dropdown .dropdown-styles {
   display: inline-block;
-  margin: 1rem;
-  width: calc(100% - 4rem);
-  background-color: rgb(var(--toolbar-background));
+  width: 100%;
+  /* background-color: var(--toolbar-background); */
 }
 
 /* toc */
@@ -193,15 +215,21 @@ body.cheat-sheet aside.nav {
   background: var(--color-white);
 }
 
-body.cheat-sheet aside.nav .nav-panel-types {
+body.cheat-sheet aside.nav .nav-panel-versions {
+  top: var(--navbar-height);
+}
+
+body.cheat-sheet aside.nav .selectors {
   position: sticky;
   top: var(--navbar-height);
   z-index: var(--z-index-toolbar);
-  height: var(--toolbar-height);
   background-color: var(--toolbar-background);
-  align-items: center;
-  display: flex;
-  box-shadow: 0 1px 0 var(--toolbar-border-color);
+  padding: 0.5rem;
+  gap: 0.5rem;
+}
+
+body.cheat-sheet aside.nav .selectors .dropdown-label {
+  font-weight: var(--body-font-weight-bold);
 }
 
 body.cheat-sheet .toc-menu-placeholder h2 {
@@ -246,7 +274,7 @@ body.cheat-sheet .toc .toc-menu a.is-active {
 
 /* headings */
 
-body.cheat-sheet h1.page:first-child {
+body.cheat-sheet .sect-header:first-child {
   display: none;
 }
 
@@ -254,9 +282,11 @@ body.cheat-sheet h2:not(.discrete) {
   display: flex;
   font-size: 2rem;
   font-weight: 600;
-  margin: 2rem 0;
   padding: 0 0.5rem;
   border: none;
+  height: 110px;
+  margin: 0;
+  line-height: 110px;
 }
 
 body.cheat-sheet h3:not(.discrete) {
@@ -284,43 +314,57 @@ body.cheat-sheet div.deprecated h3::after {
 
 /*  page */
 
+body.cheat-sheet .sect1 {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 body.cheat-sheet .sect2 {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   background: var(--color-white);
   padding: 0.5rem;
-  margin-bottom: 1rem;
+  margin: 3.5rem 0;
+}
+
+body.cheat-sheet .sect2:first-child {
+  margin-top: 0;
 }
 
 body.cheat-sheet h3 {
   flex: 100%;
   margin: 1rem 0;
   margin: 0;
-  padding: 1rem 1rem;
+  padding: 1rem 0.5rem;
 }
 
 body.cheat-sheet .exampleblock {
   width: 100%;
   margin-bottom: 0;
+  border-top: 1px solid var(--color-grey-300);
 }
 
 body.cheat-sheet .exampleblock > .content {
   display: flex;
-  flex: 0 0 100%;
+  /* flex: 0 0 100%; */
   margin-top: 0;
   padding: 0;
   border: none;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
-body.cheat-sheet .listingblock {
+body.cheat-sheet .example-block > .content > .listingblock {
+  display: flex;
   flex: 0 0 42%;
   margin: 0;
   padding: 1rem 0.5rem;
-  border-top: 1px solid var(--color-grey-300);
+  /* border-top: 1px solid var(--color-grey-300); */
 }
 
 body.cheat-sheet .listingblock .content {
+  width: 100%;
   border-radius: 0.5rem;
 }
 
@@ -328,16 +372,37 @@ body.cheat-sheet .paragraph {
   margin: 0 0 0.5rem;
 }
 
-body.cheat-sheet .description,
-body.cheat-sheet .openblock {
+body.cheat-sheet .exampleblock > .content > div {
+  display: flex;
   flex: 0 0 42%;
   flex-grow: 1;
-  padding: 1rem 0 1rem 0.5rem;
+  padding: 1rem 0.5rem;
   margin: 0;
-  border-top: 1px solid var(--color-grey-300);
 }
 
-body.cheat-sheet .description ul {
+body.cheat-sheet .exampleblock > .content > div.labels {
+  flex: 0 0 100%;
+  justify-content: flex-start;
+  padding-bottom: 0;
+  padding-top: 0;
+  gap: 0.25rem;
+}
+
+body.cheat-sheet .exampleblock > .content > div.labels span.label {
+  margin-top: 1rem;
+}
+
+body.cheat-sheet div.labels span.group--products,
+body.cheat-sheet div.page-labels span.group--products {
+  display: none;
+}
+
+body.cheat-sheet .exampleblock > .content > div.extra {
+  flex-grow: 2;
+  border-top: none;
+}
+
+body.cheat-sheet .exampleblock > .content > div.description ul {
   list-style: circle;
   line-height: 1.25;
   margin: 0;
@@ -345,13 +410,22 @@ body.cheat-sheet .description ul {
 }
 
 body.cheat-sheet .page-labels {
-  display: none;
+  display: flex;
   /* flex-grow: 1; */
-  flex-direction: row-reverse;
+  /* flex-direction: row-reverse; */
   margin: 0;
   padding: 0;
   align-items: center;
+  gap: 0.25rem;
   /* border-bottom: 1px solid var(--color-grey-200); */
+}
+
+body.cheat-sheet .sect1 > h2 {
+  padding-left: 1rem;
+}
+
+body.cheat-sheet .sect1 > .page-labels {
+  padding-right: 0.5rem;
 }
 
 body.cheat-sheet .page-labels:first-of-type {
@@ -364,16 +438,15 @@ body.cheat-sheet .page-labels p {
 }
 
 body.cheat-sheet .labels {
-  display: none;
   /* flex: 0 0 12%; */
-  padding: 1rem 0;
-  margin: 0;
-  border-top: 1px solid var(--color-grey-300);
+  /* padding: 1rem 0; */
+  /* margin: 0; */
+  /* border-top: 1px solid var(--color-grey-300); */
 }
 
 body.cheat-sheet .label {
   display: flex;
-  margin: 0.2rem;
+  /* margin: 0.2rem; */
   line-height: 1.8;
 }
 

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -475,7 +475,7 @@ html.is-clipped--nav {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  padding: 8px 12px;
+  padding: 0.5rem;
   padding-right: 28px;
   border-radius: var(--border-radius-sm);
   border: 1px solid rgb(var(--palette-light-neutral-border-strong));

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -331,7 +331,7 @@
   --nav-width: 18rem;
   --toc-top: calc(var(--body-top) + var(--toolbar-height));
   --kb-metadata-top: calc(var(--body-top) + var(--toolbar-height));
-  --toc-height: calc(100vh - var(--toc-top) - 2.5rem);
+  --toc-height: calc(100vh - var(--toc-top) - 8.5rem);
   --toc-width: calc(162 / var(--rem-base) * 1rem);
   --kb-metadata-width: calc(216 / var(--rem-base) * 1rem);
   --toc-width--widescreen: calc(216 / var(--rem-base) * 1rem);

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -52,7 +52,7 @@
     }
   }
 
-  var versionSelector = document.querySelector('.version-selector')
+  var versionSelector = document.querySelector('body:not(.cheat-sheet) .version-selector')
   if (versionSelector) {
     versionSelector.addEventListener('change', function (e) {
       const target = e.target

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -9,7 +9,8 @@
   if (levels < 0) return
 
   var article = document.querySelector('article.doc')
-  var selectorsHeight = document.querySelector('.nav-container .selectors').getBoundingClientRect().height
+  var selectors = document.querySelector('.nav-container .selectors')
+  var selectorsHeight = selectors ? selectors.getBoundingClientRect().height : 0
   var headings
   var headingSelector = []
   for (var l = 0; l <= levels; l++) headingSelector.push(l ? '.sect' + l + '>h' + (l + 1) + '[id]' : 'h1[id].sect0')
@@ -52,7 +53,7 @@
   function onScroll () {
     var scrolledBy = window.pageYOffset
     var buffer = getNumericStyleVal(document.documentElement, 'fontSize') * 1.15
-    var ceil = selectorsHeight ? article.offsetTop + (selectorsHeight * 1.15) : article.offsetTop
+    var ceil = selectors ? article.offsetTop + (selectorsHeight * 1.15) : article.offsetTop
     if (scrolledBy && window.innerHeight + scrolledBy + 2 >= document.documentElement.scrollHeight) {
       lastActiveFragment = Array.isArray(lastActiveFragment) ? lastActiveFragment : Array(lastActiveFragment || 0)
       var activeFragments = []

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -2,12 +2,14 @@
   'use strict'
 
   var sidebar = document.querySelector('aside.toc.sidebar')
+
   if (!sidebar) return
   if (document.querySelector('body.-toc')) return sidebar.parentNode.removeChild(sidebar)
   var levels = parseInt(sidebar.dataset.levels || 2)
   if (levels < 0) return
 
   var article = document.querySelector('article.doc')
+  var selectorsHeight = document.querySelector('.nav-container .selectors').getBoundingClientRect().height
   var headings
   var headingSelector = []
   for (var l = 0; l <= levels; l++) headingSelector.push(l ? '.sect' + l + '>h' + (l + 1) + '[id]' : 'h1[id].sect0')
@@ -50,7 +52,7 @@
   function onScroll () {
     var scrolledBy = window.pageYOffset
     var buffer = getNumericStyleVal(document.documentElement, 'fontSize') * 1.15
-    var ceil = article.offsetTop
+    var ceil = selectorsHeight ? article.offsetTop + (selectorsHeight * 1.15) : article.offsetTop
     if (scrolledBy && window.innerHeight + scrolledBy + 2 >= document.documentElement.scrollHeight) {
       lastActiveFragment = Array.isArray(lastActiveFragment) ? lastActiveFragment : Array(lastActiveFragment || 0)
       var activeFragments = []

--- a/src/js/06-code.js
+++ b/src/js/06-code.js
@@ -154,7 +154,7 @@ document.addEventListener('DOMContentLoaded', function () {
       })
 
       var inset = createElement('div', 'code-inset', copyButton)
-      if (language !== 'none') inset.dataset.lang = casedLang(language)
+      if (language !== 'none' && language) inset.dataset.lang = casedLang(language)
 
       inset.appendChild(copySuccess)
 

--- a/src/js/12-fragment-jumper.js
+++ b/src/js/12-fragment-jumper.js
@@ -2,6 +2,7 @@
   'use strict'
 
   var article = document.querySelector('article.doc')
+  var cheatSheet = document.querySelector('body.cheat-sheet')
   var toolbar = document.querySelector('.toolbar')
   var headerNavigationBar = document.querySelector('header > .navbar')
 
@@ -23,7 +24,15 @@
       e.preventDefault()
     }
     var topOffset = toolbar ? toolbar.getBoundingClientRect().bottom : headerNavigationBar.getBoundingClientRect().bottom
-    window.scrollTo(0, computePosition(this, 0) - topOffset)
+
+    if (cheatSheet) {
+      var scrollTarget = this.closest('div')
+      var selectorsTop = document.querySelector('.nav-container .selectors').querySelector('div').getBoundingClientRect().top
+      if (this.tagName === 'H3') topOffset = selectorsTop
+      window.scrollTo(0, computePosition(scrollTarget, 0) - topOffset)
+    } else {
+      window.scrollTo(0, computePosition(this, 0) - topOffset)
+    }
   }
 
   window.addEventListener('load', function jumpOnLoad (e) {

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -1,6 +1,33 @@
 import { createElement } from './modules/dom'
 
 document.addEventListener('DOMContentLoaded', function () {
+
+  const queryString = window.location.search
+  console.log(queryString)
+
+  const urlParams = new URLSearchParams(queryString)
+
+  if (urlParams.has('product')) {
+    const product = urlParams.get('product')
+    // set the default for the product
+    const productSelector = document.getElementById('cheat-sheet-selector')
+    const productSelectorOptions = productSelector.options
+
+    // change selected value in options list
+    let match = false
+    for (const option of productSelectorOptions) {
+      // console.log(`option:${option.label}`)
+      if (option.label === decodeURIComponent(product) || option.value === decodeURIComponent(product)) {
+        productSelector.selectedIndex = option.index
+        match = true
+      }
+    }
+    if (!match) {
+      // display some html to say that the url params are not right?
+    }
+  }
+
+
   const csSelector = '#cheat-sheet-selector'
   const cs = document.querySelector(csSelector)
 
@@ -125,6 +152,28 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // toggle for default cheat sheet selection
   const selected = cs.selectedIndex
+
+  var versionSelector = document.querySelector('body.cheat-sheet .version-selector')
+  if (versionSelector) {
+    versionSelector.addEventListener('change', function (e) {
+      const target = e.target
+
+      const selectedProduct = cs.selectedIndex
+      const current = target.dataset.current
+      const next = target.selectedOptions[0].dataset.version
+
+      const url = `${target.value}?product=${cs.options[selectedProduct].value}` 
+
+      if (window.ga) {
+        window.ga('send', 'event', 'version-select', 'From: ' + current + ';To:' + next + ';')
+      }
+      // console.log(url)
+      document.location.replace(url)
+    })
+  }
+
+
+
   toggleExamples(cs.options[selected].value)
 
   // hide and unhide sections when the selection is changed

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   if (selectionFromPath) {
     updateSelectorFromProduct(selectionFromPath)
-    updateOgFromProduct(selectionFromPath)
+    updateOgFromProduct(selectionFromPath, curURL)
   }
 
   // check for a checkbox to display or hide labels
@@ -345,18 +345,13 @@ function updateSelectorFromProduct (product) {
   }
 }
 
-function updateOgFromProduct (product) {
-  const ogUrl = document.querySelector('meta[property="og:url"]')
-  const ogUrlContent = ogUrl.getAttribute('content')
-
+function updateOgFromProduct (product, curURL) {
   const ogDesc = document.querySelector('meta[property="og:description"]')
-
-  const ogUrlFromProduct = stripTrailingSlash(ogUrlContent) + '/' + product
-
+  const ogUrl = document.querySelector('meta[property="og:url"]')
   const text = getProductFromOptionMap(product)
   const ogDescFromProduct = 'Cypher Cheat Sheet - ' + text
 
-  ogUrl.setAttribute('content', ogUrlFromProduct)
+  ogUrl.setAttribute('content', curURL)
   ogDesc.setAttribute('content', ogDescFromProduct)
 }
 

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   if (selectionFromPath) {
     updateSelectorFromProduct(selectionFromPath)
-    updateOgFromProduct(selectionFromPath, curURL)
+    updateMetaFromProduct(selectionFromPath, curURL)
   }
 
   // check for a checkbox to display or hide labels
@@ -345,14 +345,18 @@ function updateSelectorFromProduct (product) {
   }
 }
 
-function updateOgFromProduct (product, curURL) {
+function updateMetaFromProduct (product, curURL) {
   const ogDesc = document.querySelector('meta[property="og:description"]')
+  const ogTitle = document.querySelector('meta[property="og:title"]')
   const ogUrl = document.querySelector('meta[property="og:url"]')
+
   const text = getProductFromOptionMap(product)
   const ogDescFromProduct = 'Cypher Cheat Sheet - ' + text
 
   ogUrl.setAttribute('content', curURL)
   ogDesc.setAttribute('content', ogDescFromProduct)
+  ogTitle.setAttribute('content', ogDescFromProduct)
+  document.title = ogDescFromProduct
 }
 
 const stripTrailingSlash = (str) => {

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -1,7 +1,6 @@
 import { createElement } from './modules/dom'
 
 document.addEventListener('DOMContentLoaded', function () {
-
   const queryString = window.location.search
   console.log(queryString)
 
@@ -26,7 +25,6 @@ document.addEventListener('DOMContentLoaded', function () {
       // display some html to say that the url params are not right?
     }
   }
-
 
   const csSelector = '#cheat-sheet-selector'
   const cs = document.querySelector(csSelector)
@@ -162,7 +160,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const current = target.dataset.current
       const next = target.selectedOptions[0].dataset.version
 
-      const url = `${target.value}?product=${cs.options[selectedProduct].value}` 
+      const url = `${target.value}?product=${cs.options[selectedProduct].value}`
 
       if (window.ga) {
         window.ga('send', 'event', 'version-select', 'From: ' + current + ';To:' + next + ';')
@@ -171,8 +169,6 @@ document.addEventListener('DOMContentLoaded', function () {
       document.location.replace(url)
     })
   }
-
-
 
   toggleExamples(cs.options[selected].value)
 

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -24,23 +24,15 @@ const prodMatrix = {
 }
 
 const defaultClasses = ['exampleblock', 'sect2', 'sect1']
-// const selectorTypes = [...new Set(optionMap.map((obj) => obj.labelType))]
 
 document.addEventListener('DOMContentLoaded', function () {
   if (!document.querySelector('body.cheat-sheet')) return
 
-  // const curURL = new URL('https://example.com/docs/cypher-cheat-sheet/4.1/auradb-free/')
   const curURL = document.location
   const selectionFromPath = getSelectionFromPath(curURL)
 
   if (selectionFromPath) {
     updateSelectorFromProduct(selectionFromPath)
-  } else {
-    const queryString = window.location.search
-    const selectionFromProduct = getSelectionFromProduct(queryString)
-    if (selectionFromProduct) {
-      updateSelectorFromProduct(selectionFromProduct)
-    }
   }
 
   // check for a checkbox to display or hide labels
@@ -52,37 +44,10 @@ document.addEventListener('DOMContentLoaded', function () {
     })
   }
 
-  // if (urlParams.has('category')) {
-  //   const category = urlParams.get('category')
-  //   // set the default for the category
-  //   const categorySelector = document.getElementById('cheat-sheet-selector-categories')
-  //   const categorySelectorOptions = categorySelector.options
-
-  //   // change selected value in options list
-  //   let match = false
-  //   for (const option of categorySelectorOptions) {
-  //     // console.log(`option:${option.label}`)
-  //     if (option.label === decodeURIComponent(category) || option.value === decodeURIComponent(category)) {
-  //       categorySelector.selectedIndex = option.index
-  //       match = true
-  //     }
-  //   }
-  //   if (!match) {
-  //     // display some html to say that the url params are not right?
-  //   }
-  // }
-
   const optionNames = [...selectorOptions].reduce(function (f, o) {
     f.push(o.value)
     return f
   }, []).sort()
-
-  // console.log(`optionNames: ${optionNames}`)
-
-  // const visibleOptionNames = [...selectorOptions].reduce(function (f, o) {
-  //   if (!o.hidden) f.push(o.value)
-  //   return f
-  // }, []).sort()
 
   const hiddenOptionNames = [...selectorOptions].reduce(function (f, o) {
     if (o.hidden) f.push(o.value)
@@ -273,13 +238,6 @@ function selectorMatch (hiddenOptionNames) {
   })
   )
 
-  // selectedValues.forEach((s) => {
-  //   // get all the values for this type
-  //   const these = [...new Set(optionMap.filter(function (f) {
-  //     return f.labelType === s.type && f.value !== 'all' && f.inScope
-  //   }).map((obj) => obj.value))]
-  // })
-
   // hide headers and example sections that don't have labels for all the current selections
   document.querySelectorAll('div.sect2:not(.cs-all), div.exampleblock:not(.cs-all)').forEach((el) => {
     const classes = removeDefaultClasses([...el.classList])
@@ -288,10 +246,6 @@ function selectorMatch (hiddenOptionNames) {
     let display = true
 
     selectedValues.forEach((s) => {
-      // console.log(`selected: ${s.type} : ${s.value}`)
-
-      // which value for s.type is selected?
-
       // get all the values for this type
       const these = [...new Set(optionMap.filter(function (f) {
         return f.labelType === s.type && f.value !== 'all' && f.inScope
@@ -302,10 +256,7 @@ function selectorMatch (hiddenOptionNames) {
         return f.labelType === s.type && f.value !== 'all' && !f.inScope
       }).map((obj) => obj.value))]
 
-      // console.log(`not in scope: ${notInScope}`)
-
       // what make us want to hide an example?
-
       // 1. if it has a class for one or more of this type, but not the selected one, and all isn't selected for this type
       if (these.some((v) => classes.includes(v)) && (!classes.includes(s.value) && s.value !== 'all')) {
         // console.log(`el will be hidden based on classes (${classes}) versus current type ${s.type} (${these}), and current selection (${s.value})`)
@@ -317,10 +268,6 @@ function selectorMatch (hiddenOptionNames) {
         // console.log(`el will be hidden based on classes (${classes}) versus current type ${s.type} (${these}), and current selection (${s.value})`)
         display = false
       }
-
-      // how about the difference between additive and subtractive labels?
-      // ie no product = all products, but no category does not mean all categories?
-      // if a category is chosen then the el has to have that to be displayed?
     })
 
     if (display) {
@@ -328,8 +275,6 @@ function selectorMatch (hiddenOptionNames) {
     } else {
       el.classList.add('hidden')
       el.classList.remove('selectors-match')
-      // console.log('getting out of here')
-      // return
     }
 
     if (hiddenOptionNames.some((v) => classes.includes(v))) {
@@ -340,12 +285,10 @@ function selectorMatch (hiddenOptionNames) {
   })
 
   document.querySelectorAll('.selectors-match .sect2:not(.hidden), .selectors-match .exampleblock:not(.hidden)').forEach((ch) => {
-    // console.log('adding to child')
     ch.classList.add('selectors-match')
   })
 
   document.querySelectorAll('.label-match .sect2, .label-match .exampleblock').forEach((ch) => {
-    // console.log('adding to child')
     ch.classList.add('label-match')
   })
 
@@ -356,14 +299,6 @@ function selectorMatch (hiddenOptionNames) {
   document.querySelectorAll('div.sect2.selectors-match').forEach((el) => {
     el.closest('.sect1').classList.add('selectors-match')
   })
-
-  // document.querySelectorAll('div.exampleblock.label-match').forEach((el) => {
-  //   el.closest('.sect2').classList.add('label-match')
-  // })
-
-  // document.querySelectorAll('div.sect2.label-match').forEach((el) => {
-  //   el.closest('.sect1').classList.add('label-match')
-  // })
 
   // hide headers and example sections that don't have labels for all the current selections
   document.querySelectorAll('div.exampleblock:not(.selectors-match), div.sect2:not(.selectors-match), div.sect1:not(.selectors-match)').forEach((el) => {
@@ -411,16 +346,6 @@ function updateSelectorFromProduct (product) {
 
 const stripTrailingSlash = (str) => {
   return str.endsWith('/') ? str.slice(0, -1) : str
-}
-
-function getSelectionFromProduct (queryString) {
-  const urlParams = new URLSearchParams(queryString)
-  if (urlParams.has('product')) {
-    const queryProduct = urlParams.get('product')
-    if (Object.values(prodMatrix).includes(queryProduct)) {
-      return queryProduct
-    }
-  }
 }
 
 function getSelectionFromPath (pageURL) {

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   if (selectionFromPath) {
     updateSelectorFromProduct(selectionFromPath)
+    updateOgFromProduct(selectionFromPath)
   }
 
   // check for a checkbox to display or hide labels
@@ -118,7 +119,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const p = createElement('p')
     const span = createElement('span', `label label--${match} group--${group}`)
 
-    const text = optionMap.find((label) => label.value === match).text
+    const text = getProductFromOptionMap(match)
 
     span.textContent = text
     p.appendChild(span)
@@ -344,6 +345,21 @@ function updateSelectorFromProduct (product) {
   }
 }
 
+function updateOgFromProduct (product) {
+  const ogUrl = document.querySelector('meta[property="og:url"]')
+  const ogUrlContent = ogUrl.getAttribute('content')
+  
+  const ogDesc = document.querySelector('meta[property="og:description"]')
+
+  const ogUrlFromProduct = stripTrailingSlash(ogUrlContent) + '/' + product
+
+  const text = getProductFromOptionMap(product)
+  const ogDescFromProduct = 'Cypher Cheat Sheet - ' + text
+
+  ogUrl.setAttribute('content',ogUrlFromProduct)
+  ogDesc.setAttribute('content',ogDescFromProduct)
+}
+
 const stripTrailingSlash = (str) => {
   return str.endsWith('/') ? str.slice(0, -1) : str
 }
@@ -378,4 +394,9 @@ function toggleLabels (l) {
       div.style.display = 'none'
     }
   })
+}
+
+function getProductFromOptionMap (prod) {
+  const name = optionMap.find((opt) => opt.value === prod).text
+  return name
 }

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -16,20 +16,14 @@ document.addEventListener('DOMContentLoaded', function () {
   // const curURL = new URL('https://development.neo4j.dev/docs/cypher-cheat-sheet/4.1/auradb-free/')
   const curURL = document.location
   const selectionFromPath = getSelectionFromPath(curURL)
-  // use query parameter to set product selector
-  const queryString = window.location.search
-  const urlParams = new URLSearchParams(queryString)
-  if (urlParams.has('product')) {
-    const product = urlParams.get('product')
-    updateSelectorFromProduct(product)
+
+  if (selectionFromPath) {
+    updateSelectorFromProduct(selectionFromPath)
   } else {
-    // use URL to set product selector
-    // if we are proxying by using a different url, use it to update the selected option
-    console.log(document.location)
-    console.log(document.location.href)
-    if (selectionFromPath) {
-      updateSelectorFromProduct(selectionFromPath)
-      // if we've got a selector update from the path, we need to update the paths in the version selector
+    const queryString = window.location.search
+    const selectionFromProduct = getSelectionFromProduct(queryString)
+    if (selectionFromProduct) {
+      updateSelectorFromProduct(selectionFromProduct)
     }
   }
 
@@ -127,12 +121,9 @@ document.addEventListener('DOMContentLoaded', function () {
     else div.classList.add('page-labels')
     const p = createElement('p')
     const span = createElement('span', `label label--${match}`)
-
     const text = optionMap.find((label) => label.value === match).text
-    // console.log(text)
     span.textContent = text
     p.appendChild(span)
-
     // if there is a label div, add the new label
     const labelsDiv = el.firstElementChild.querySelector('div.labels')
     if (labelsDiv) {
@@ -142,11 +133,6 @@ document.addEventListener('DOMContentLoaded', function () {
       el.firstElementChild.appendChild(div)
     }
   }
-
-  // auto-add labels according to examples and sections classes
-  // document.querySelectorAll(`div.exampleblock)`).forEach((el) => {
-  // el.classList.toggle('hidden')
-  // })
 
   // hide labels for versions that are not available in the select box
   document.querySelectorAll('span.label').forEach((el) => {
@@ -175,12 +161,10 @@ document.addEventListener('DOMContentLoaded', function () {
         newUrl = `${target.value}?product=${cs.options[selectedProduct].value}`
       }
 
-      // url = `${target.value}?product=${cs.options[selectedProduct].value}`
-
       if (window.ga) {
         window.ga('send', 'event', 'version-select', 'From: ' + current + ';To:' + next + ';')
       }
-      // console.log(newUrl)
+
       document.location.replace(newUrl)
     })
   }
@@ -302,6 +286,16 @@ const stripTrailingSlash = (str) => {
   return str.endsWith('/') ? str.slice(0, -1) : str
 }
 
+function getSelectionFromProduct (queryString) {
+  const urlParams = new URLSearchParams(queryString)
+  if (urlParams.has('product')) {
+    const queryProduct = urlParams.get('product')
+    if (Object.values(prodMatrix).includes(queryProduct)) {
+      return queryProduct
+    }
+  }
+}
+
 function getSelectionFromPath (pageURL) {
   const pathArr = stripTrailingSlash(pageURL.pathname).split('/')
   if (pathArr[0] === '') pathArr.shift()
@@ -311,9 +305,7 @@ function getSelectionFromPath (pageURL) {
   // the second item in values should be the product
   const pathProduct = values[1]
   if (!pathProduct) return
-
   // parse pathProduct to match something you could select in the product dropdown
-  console.log(`testing for ${pathProduct}`)
   if (Object.keys(prodMatrix).includes(pathProduct)) {
     return prodMatrix[pathProduct]
   }

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -25,6 +25,49 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
+  const stripTrailingSlash = (str) => {
+    return str.endsWith('/') ? str.slice(0, -1) : str
+  }
+
+  // if we are proxying by using a different url, use it to update the selected option
+  const testURL = new URL('https://development.neo4j.dev/docs/cypher-cheat-sheet/4.1/auradb-free/')
+
+  // let testURL = document.location
+
+  const pathBits = stripTrailingSlash(testURL.pathname).split('/')
+  console.log(pathBits)
+
+  const goodPath = pathBits.slice(pathBits.indexOf('cypher-cheat-sheet'))
+  goodPath.shift()
+
+  console.log(goodPath)
+
+  // the first item in goodPath should be the version
+  const csVersion = document.querySelector('body.cheat-sheet .version-selector').dataset.current
+
+  if (goodPath[0] !== csVersion && goodPath[0] !== 'current') console.log('version mismatch')
+
+  // the second item in goodPath should be the product
+  const pathProduct = goodPath[1]
+
+  // parse this value to match something you could select in the product dropdown
+
+  const prodMatrix = {
+    'auradb-free': 'aura-dbf',
+    'auradb-professional': 'aura-dbp',
+    'auradb-enterprise': 'aura-dbe',
+    'aurads-professional': 'aura-dsp',
+    'aurads-enterprise': 'aura-dse',
+    'neo4j-community': 'neo4j-ce',
+    'neo4j-enterprise': 'neo4j-ee',
+  }
+
+  const selectionFromPath = prodMatrix[pathProduct]
+
+  console.log(selectionFromPath)
+
+  //////
+
   const csSelector = '#cheat-sheet-selector'
   const cs = document.querySelector(csSelector)
 

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -348,7 +348,7 @@ function updateSelectorFromProduct (product) {
 function updateOgFromProduct (product) {
   const ogUrl = document.querySelector('meta[property="og:url"]')
   const ogUrlContent = ogUrl.getAttribute('content')
-  
+
   const ogDesc = document.querySelector('meta[property="og:description"]')
 
   const ogUrlFromProduct = stripTrailingSlash(ogUrlContent) + '/' + product
@@ -356,8 +356,8 @@ function updateOgFromProduct (product) {
   const text = getProductFromOptionMap(product)
   const ogDescFromProduct = 'Cypher Cheat Sheet - ' + text
 
-  ogUrl.setAttribute('content',ogUrlFromProduct)
-  ogDesc.setAttribute('content',ogDescFromProduct)
+  ogUrl.setAttribute('content', ogUrlFromProduct)
+  ogDesc.setAttribute('content', ogDescFromProduct)
 }
 
 const stripTrailingSlash = (str) => {

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -15,7 +15,6 @@ document.addEventListener('DOMContentLoaded', function () {
     // change selected value in options list
     let match = false
     for (const option of productSelectorOptions) {
-      // console.log(`option:${option.label}`)
       if (option.label === decodeURIComponent(product) || option.value === decodeURIComponent(product)) {
         productSelector.selectedIndex = option.index
         match = true

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -8,8 +8,9 @@
   {{#if (or (eq @root.page.layout 'training-certification') (eq @root.page.layout 'training-enrollment') (eq @root.page.layout 'training'))}}
     <script src="//go.neo4j.com/js/forms2/js/forms2.min.js"></script>
   {{/if}}
-  {{#if (and (eq page.attributes.theme "cheat-sheet") (not (eq site.url "http://localhost:5252")))}}
+  {{#if (and (eq @root.page.attributes.theme "cheat-sheet") (not (eq @root.site.url "http://localhost:5252")))}}
   <script src="{{{@root.site.path}}}{{{@root.site.ui.url}}}/js/vendor/auth0.js"></script>
+  
   <script src="{{{@root.site.path}}}{{{@root.site.ui.url}}}/js/site.js"></script>
   {{!-- <script async src="{{{@root.site.path}}}{{{@root.site.ui.url}}}/js/vendor/gram.js"></script> --}}
   <script async src="{{{@root.site.path}}}{{{@root.site.ui.url}}}/js/vendor/highlight.js"></script>

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -8,11 +8,19 @@
   {{#if (or (eq @root.page.layout 'training-certification') (eq @root.page.layout 'training-enrollment') (eq @root.page.layout 'training'))}}
     <script src="//go.neo4j.com/js/forms2/js/forms2.min.js"></script>
   {{/if}}
+  {{#if (and (eq page.attributes.theme "cheat-sheet") (not (eq site.url "http://localhost:5252")))}}
+  <script src="{{{@root.site.path}}}{{{@root.site.ui.url}}}/js/vendor/auth0.js"></script>
+  <script src="{{{@root.site.path}}}{{{@root.site.ui.url}}}/js/site.js"></script>
+  {{!-- <script async src="{{{@root.site.path}}}{{{@root.site.ui.url}}}/js/vendor/gram.js"></script> --}}
+  <script async src="{{{@root.site.path}}}{{{@root.site.ui.url}}}/js/vendor/highlight.js"></script>
+  <script async src="{{{@root.site.path}}}{{{@root.site.ui.url}}}/js/vendor/image-zoom.js"></script>
+  {{else}}
   <script src="{{{this}}}/js/vendor/auth0.js"></script>
   <script src="{{{this}}}/js/site.js"></script>
   {{!-- <script async src="{{{this}}}/js/vendor/gram.js"></script> --}}
   <script async src="{{{this}}}/js/vendor/highlight.js"></script>
   <script async src="{{{this}}}/js/vendor/image-zoom.js"></script>
+  {{/if}}
 {{/with}}
 
 {{#if page.attributes.includedriver}}

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -4,6 +4,9 @@
 {{#if page.attributes.cdn}}
     <link rel="preload" href="{{{page.attributes.cdn}}}/fonts/fontawesome-webfont.woff2?v=4.7.0" as="font">
     <link rel="stylesheet" href="{{{page.attributes.cdn}}}/css/site.css">
+{{else if (and (eq page.attributes.theme "cheat-sheet") (not (eq site.url "http://localhost:5252")))}}
+    <link rel="preload" href="{{{@root.site.path}}}{{{@root.site.ui.url}}}/fonts/fontawesome-webfont.woff2?v=4.7.0" as="font">
+    <link rel="stylesheet" href="{{{@root.site.path}}}{{{@root.site.ui.url}}}/css/site.css">
 {{else}}
     <link rel="preload" href="{{{uiRootPath}}}/fonts/fontawesome-webfont.woff2?v=4.7.0" as="font">
     <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -4,7 +4,7 @@
 {{#if page.attributes.cdn}}
     <link rel="preload" href="{{{page.attributes.cdn}}}/fonts/fontawesome-webfont.woff2?v=4.7.0" as="font">
     <link rel="stylesheet" href="{{{page.attributes.cdn}}}/css/site.css">
-{{else if (and (eq page.attributes.theme "cheat-sheet") (not (eq site.url "http://localhost:5252")))}}
+{{else if (and (eq page.attributes.theme "cheat-sheet") (not (eq @root.site.url "http://localhost:5252")))}}
     <link rel="preload" href="{{{@root.site.path}}}{{{@root.site.ui.url}}}/fonts/fontawesome-webfont.woff2?v=4.7.0" as="font">
     <link rel="stylesheet" href="{{{@root.site.path}}}{{{@root.site.ui.url}}}/css/site.css">
 {{else}}

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -94,7 +94,6 @@
     <div id="topbar-nav" class="navbar-menu">
       {{#if (eq page.attributes.theme 'cheat-sheet') }}
       <div class="navbar-start">
-        {{> nav-explore}}
         <span class="navbar-link">
           <a href="/docs/cypher-manual/{{this.displayVersion}}" class="project-link external">Cypher documentation</a>
         </span>

--- a/src/partials/nav-explore.hbs
+++ b/src/partials/nav-explore.hbs
@@ -11,7 +11,7 @@
       </option>
       {{/with}}
       {{#each page.versions}}
-      {{#unless this.prerelease}}
+      {{#unless (or this.prerelease (and (eq this.version @root.page.version) (eq @root.page.attributes.theme 'cheat-sheet') ))}}
       <option
         data-version="{{this.displayVersion}}"
         value="{{{relativize this.url}}}"

--- a/src/partials/nav-menu.hbs
+++ b/src/partials/nav-menu.hbs
@@ -1,3 +1,11 @@
+{{#if (eq page.attributes.theme 'cheat-sheet') }}
+  <aside class="toc sidebar" data-title="{{or page.attributes.toctitle ''}}"
+  data-levels="{{{or page.attributes.toclevels 2}}}">
+  <div class="toc-menu">
+    <div class="toc-menu-placeholder"></div>
+  </div>
+</aside>
+{{else}}
 {{#with page.navigation}}
 <div class="nav-panel-menu is-active" data-panel="menu">
     <nav class="nav-menu">
@@ -10,3 +18,4 @@
   </nav>
 </div>
 {{/with}}
+{{/if}}

--- a/src/partials/nav-selectors.hbs
+++ b/src/partials/nav-selectors.hbs
@@ -1,0 +1,92 @@
+{{#if page.versions.[1]}}
+<div class="nav-panel-versions{{#unless page.navigation}} is-active{{/unless}}" data-panel="explore">
+
+  <div class="dropdown">
+    <span class="dropdown-label">{{#with (or page.attributes.cheatsheet-product 'Product')}}{{this}}{{/with}} Version</span>
+
+    <select data-current="{{@root.page.version}}" class="version-selector dropdown-styles">
+      {{#with @root.page.componentVersion}}
+      <option value="" selected>
+        {{#unless (or @root.page.attributes.nav-hide-component-title (eq @root.page.attributes.theme 'cheat-sheet'))}} {{{ ./title }}} {{/unless}}{{ this.displayVersion }}{{#if (and @root.page.attributes.nav-indicate-latest (eq @root.page.version @root.page.latest.version)) }} (latest){{/if}}
+      </option>
+      {{/with}}
+      {{#each page.versions}}
+      {{#unless (or this.prerelease (and (eq this.version @root.page.version) (eq @root.page.attributes.theme 'cheat-sheet') ))}}
+      <option
+        data-version="{{this.displayVersion}}"
+        value="{{{relativize this.url}}}"
+        {{~#if this.missing}} disabled{{/if}}
+      >
+        {{ this.displayVersion }}{{#if (and @root.page.attributes.nav-indicate-latest (eq this.version @root.page.latest.version)) }} (latest){{/if}}
+      </option>
+      {{/unless}}
+      {{/each}}
+    </select>
+  </div>
+</div>
+{{/if}}
+
+{{#if (eq page.attributes.theme 'cheat-sheet') }}
+<div class="nav-panel-types{{#unless page.navigation}} is-active{{/unless}}" data-panel="explore" data-selector-type="products">
+  <div class="dropdown">
+    <select id="cheat-sheet-selector-products" class="cs-selector dropdown-styles" data-label-type="products">
+      {{!-- <option value="all" data-label="all" data-class="all" data-label-type="products">All</option> --}}
+      {{#each page.attributes.cheatsheet-products}}
+      {{#if this.default}}
+      <option value="{{this.class}}" data-label="{{#with (or this.label this.name) }}{{{this}}}{{/with}}" data-class="{{this.class}}" data-label-type="products" selected>{{this.name}}</option>
+      {{else}}
+      <option value="{{this.class}}" data-label="{{#with (or this.label this.name) }}{{{this}}}{{/with}}" data-class="{{this.class}}" data-label-type="products" {{#if this.label-only }}hidden{{/if}}>{{this.name}}</option>
+      {{/if}}
+      {{/each}}
+    </select>
+    {{!-- <div class="toggle-menu">
+      <label class="form-item-label cursor-pointer">
+        <input type="checkbox" role="checkbox" id="products-highlight">
+      </label>
+    </div> --}}
+  </div>
+</div>
+
+{{#if page.attributes.cheatsheet-categories}}
+<div class="nav-panel-types{{#unless page.navigation}} is-active{{/unless}}" data-panel="explore"  data-selector-type="categories">
+  {{!-- categories - eg read, write, structure, general --}}
+  <div class="dropdown">
+    <select id="cheat-sheet-selector-categories" class="cs-selector dropdown-styles" data-label-type="categories">
+      <option value="all" data-label="all" data-class="all" data-label-type="categories">All</option>
+      {{#each page.attributes.cheatsheet-categories}}
+      {{#if this.default}}
+      <option value="{{this.class}}" data-label="{{#with (or this.label this.name) }}{{{this}}}{{/with}}" data-class="{{this.class}}" data-label-type="categories" selected>{{this.name}}</option>
+      {{else}}
+      <option value="{{this.class}}" data-label="{{#with (or this.label this.name) }}{{{this}}}{{/with}}" data-class="{{this.class}}" data-label-type="categories" {{#if this.label-only }}hidden{{/if}}>{{this.name}}</option>
+      {{/if}}
+      {{/each}}
+    </select>
+
+    <div class="toggle-menu">
+      <label class="form-item-label cursor-pointer">
+        <input type="checkbox" role="checkbox" id="categories-highlight" checked="true">
+      </label>
+    </div>
+  </div>
+</div>
+{{/if}}
+
+{{!-- {{#if page.attributes.cheatsheet-labels}}
+<div class="nav-panel-types{{#unless page.navigation}} is-active{{/unless}}" data-panel="explore" data-selector-type="labels">
+  <div class="dropdown">
+    <select id="cheat-sheet-selector-labels" class="cs-selector dropdown-styles" data-label-type="labels">
+      <option value="all" data-label="all" data-class="all" data-label-type="labels">All</option>
+      {{#each page.attributes.cheatsheet-labels}}
+      {{#if this.default}}
+      <option value="{{this.class}}" data-label="{{#with (or this.label this.name) }}{{{this}}}{{/with}}" data-class="{{this.class}}" data-label-type="labels" selected>{{this.name}}</option>
+      {{else}}
+      <option value="{{this.class}}" data-label="{{#with (or this.label this.name) }}{{{this}}}{{/with}}" data-class="{{this.class}}" data-label-type="labels" {{#if this.label-only }}hidden{{/if}}>{{this.name}}</option>
+      {{/if}}
+      {{/each}}
+    </select>
+  </div>
+</div>
+{{/if}} --}}
+
+
+{{/if}}

--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -1,12 +1,10 @@
 <div class="nav-container"{{#if page.component}} data-component="{{page.component.name}}" data-version="{{page.version}}"{{/if}}>
   <aside class="nav">
     <div class="panels">
-    {{#if (eq page.attributes.theme 'cheat-sheet') }}
-      {{> nav-cheat-sheet}}
-    {{else}}
-      {{> nav-explore}}
+      <div class="selectors">
+        {{> nav-selectors}}
+      </div>
       {{> nav-menu}}
-    {{/if}}
     </div>
   </aside>
 </div>


### PR DESCRIPTION
Improves the cheat sheet experience when we have Aura and Neo4j cheat sheets published together. Will require a slight modification to playbooks:

asciidoc attributes are now:

```
    page-cheatsheet-product: Neo4j
    page-cheatsheet-products:
        - name: 'Neo4j Community Edition'
          class: 'neo4j-ce'
        ...
```

Will allow us to serve up the same cheat sheet html page at multiple locations, so it will be accessible at `neo4j.com/docs/cypher-cheat-sheet/<version>/<product>/` where `<version>` is 4 or 5, and `<product>` is eg `neo4j-ee`, `aura-dbe` etc