### PR TITLE
roles: fix margin

### DIFF
--- a/preview-src/docs-roles.adoc
+++ b/preview-src/docs-roles.adoc
@@ -15,6 +15,29 @@ Blocks with the appropriate roles have text appended.
 
 Lorem ipsum dolor `code test` sit
 
+Roles can be added anywhere, for example this definition list item has a role.
+
+[enterprise-edition]#Pipelined#::
+In the _pipelined_ runtime, the operators are grouped into pipelines in the execution plan to generate new combinations and orders of execution, which are optimized for performance and memory usage.
+
+And so does this table
+
+[options="header",cols="2m,2a,^1a"]
+|===
+|Option
+|Description
+|Default
+
+|`runtime=slotted`
+|Forces the Cypher query planner to use the _slotted_ runtime.
+|Default for Community Edition.
+
+|[enterprise-edition]#runtime=pipelined#
+| Forces the Cypher query planner to use the _pipelined_ runtime.
+| Default for Enterprise Edition.
+|===
+
+
 [role=aura-db-enterprise]
 == AuraDB Enterprise
 

--- a/src/css/neo4j-docs.css
+++ b/src/css/neo4j-docs.css
@@ -114,7 +114,7 @@ span.fabric::after {
   border-width: 1px;
   border-radius: 6px;
   bottom: 2px;
-  /* margin-left: 8px; */
+  margin-left: 8px;
 }
 
 .sect1.show-roles h2::after,
@@ -148,7 +148,8 @@ span.fabric::after {
   padding-bottom: 0.5rem;
 }
 
-.sect1 div.roles > span.role {
+.sect1 div.roles > span.role,
+div.roles > span.role::after {
   margin: 0;
 }
 


### PR DESCRIPTION
Makes sure there is a left margin before the role when displayed in definition lists and monospace table cells