### PR TITLE
fix missing headers in docs home theme

### DIFF
--- a/src/js/60-docs-roles.js
+++ b/src/js/60-docs-roles.js
@@ -1,11 +1,11 @@
 import { createElement } from './modules/dom'
 
 document.addEventListener('DOMContentLoaded', function () {
-  const sectionDivs = document.querySelectorAll('body.docs div[class^="sect"]:not(.sectionbody,.sect-header)')
+  const sectionDivs = document.querySelectorAll('body.docs:not(.docshome) div[class^="sect"]:not(.sectionbody,.sect-header)')
   sectionDivs.forEach(function (sectionDiv) {
     var roles = sectionDiv.classList
     roles = [...roles].sort().filter(function (c) {
-      return (!c.startsWith('sect'))
+      return (!(c.startsWith('sect') || c === 'display'))
     })
 
     if (roles.length === 0) return


### PR DESCRIPTION
Updates to how roles are displayed next to headers caused a problem with the docs-home theme. 

This PR restores missing headers in docs home pages.