### PR TITLE
Remove excessive padding-bottom in blockquotes.

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -524,7 +524,7 @@ body {
   background: var(--quote-background);
   border-left: 5px solid var(--quote-border-color);
   color: var(--quote-font-color);
-  padding: 0.25rem 2rem 1.25rem;
+  padding: 0.25rem 2rem 0.25rem;
 }
 
 .doc .quoteblock .attribution {


### PR DESCRIPTION
Before
![Screenshot from 2023-06-12 13-50-34](https://github.com/neo4j-documentation/docs-ui/assets/114478074/6787926c-a47e-4cab-9af4-038723a58848)

After
![Screenshot from 2023-06-12 13-49-55](https://github.com/neo4j-documentation/docs-ui/assets/114478074/96fcbe7b-1cba-404b-9d09-4e5ca501a505)
