### PR TITLE
Fix css selector nesting in drivers landing page

### DIFF
--- a/src/css/docs-home.css
+++ b/src/css/docs-home.css
@@ -64,7 +64,7 @@ body.docshome .doc h2::after {
   content: "";
 }
 
-body.docshome .doc div:not(.display) h2 {
+body.docshome .doc div:not(.display) div h2 {
   display: none;
 }
 

--- a/src/css/neo4j-docs.css
+++ b/src/css/neo4j-docs.css
@@ -142,7 +142,7 @@ span.fabric::after {
   margin-bottom: 1rem;
 }
 
-.sect1 > .sect-header {
+.sect1:not(.display) > .sect-header {
   border-bottom: 1px solid var(--section-divider-color);
   margin-bottom: 1rem;
   padding-bottom: 0.5rem;


### PR DESCRIPTION
Before
![Screenshot from 2023-06-14 08-27-51](https://github.com/neo4j-documentation/docs-ui/assets/114478074/bde29514-e6bb-4a56-b71e-13093ecb6736)

After
![Screenshot from 2023-06-14 08-27-05](https://github.com/neo4j-documentation/docs-ui/assets/114478074/0d0b25f0-888c-4188-bf15-1c1695740103)

Reason is the effect of `[.display]` in the asciidoc, which doesn't get appended to the div closest to the h2.
![Screenshot from 2023-06-14 08-27-36](https://github.com/neo4j-documentation/docs-ui/assets/114478074/03311d3c-8bbe-4ebe-818d-1a32e9ef04eb)

This also has the effect of fixing the style of docs-archive as I suppose it was intention to have it from the start:
![localhost_8000_docs_resources_docs-archive_ (1)](https://github.com/neo4j-documentation/docs-ui/assets/114478074/6f2ba6d1-4e2a-4efc-987b-14164ea702c0)

Sister PR
https://github.com/neo-technology/docs-home/pull/74