### PR TITLE
Fix code blocks style

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -187,6 +187,14 @@ body {
   font-size: calc(16 / var(--rem-base) * 1rem);
   line-height: 1.5;
   margin: 0;
+  background: var(--pre-background);
+  display: block;
+  overflow-x: auto;
+  width: 100%;
+  height: 100%;
+  padding: 1.5rem 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
 }
 
 .doc code::before {
@@ -721,18 +729,6 @@ body {
 .doc .tableblock pre,
 .doc .listingblock.wrap pre {
   white-space: pre-wrap;
-}
-
-.doc pre:not(.highlight),
-.doc pre.highlight code {
-  background: var(--pre-background);
-  display: block;
-  overflow-x: auto;
-  width: 100%;
-  height: 100%;
-  padding: 1.5rem 0.5rem;
-  border-bottom-left-radius: 0.5rem;
-  border-bottom-right-radius: 0.5rem;
 }
 
 .doc .listingblock:not(.has-title) pre.highlight {


### PR DESCRIPTION
The background reason lies in fixing the scrollbar when code blocks are embedded in summary tags, as in #180. The issue stems from `width: 100%`, and shifting all the surrounding style to the `pre` container fixes that and also removes an extra set of rules, by merging it with an already existent set. No conflicts or regressions noticed on a bunch of docsets I tested it against.

Before
![before](https://github.com/neo4j-documentation/docs-ui/assets/114478074/c6232062-bfe0-4763-b495-0d41aec12157)

After
![after](https://github.com/neo4j-documentation/docs-ui/assets/114478074/88264ae0-bd2b-46b9-9116-6a54abb15293)
