### PR TITLE
Fix regression in code blocks style

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -187,14 +187,6 @@ body {
   font-size: calc(16 / var(--rem-base) * 1rem);
   line-height: 1.5;
   margin: 0;
-  background: var(--pre-background);
-  display: block;
-  overflow-x: auto;
-  width: 100%;
-  height: 100%;
-  padding: 1.5rem 0.5rem;
-  border-bottom-left-radius: 0.5rem;
-  border-bottom-right-radius: 0.5rem;
 }
 
 .doc code::before {
@@ -729,6 +721,18 @@ body {
 .doc .tableblock pre,
 .doc .listingblock.wrap pre {
   white-space: pre-wrap;
+}
+
+.doc pre:not(.highlight),
+.doc pre.highlight code {
+  background: var(--pre-background);
+  display: block;
+  overflow-x: auto;
+  /*width: 100%;*/
+  height: 100%;
+  padding: 1.5rem 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
 }
 
 .doc .listingblock:not(.has-title) pre.highlight {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -728,7 +728,7 @@ body {
   background: var(--pre-background);
   display: block;
   overflow-x: auto;
-  /*width: 100%;*/
+  /* width: 100%; */
   height: 100%;
   padding: 1.5rem 0.5rem;
   border-bottom-left-radius: 0.5rem;


### PR DESCRIPTION
This reverts https://github.com/neo4j-documentation/docs-ui/pull/181/files + removes the `width` property on code, which also fixes the issue raised in #181 and doesn't seem to cause any more. The issue with #181 is the broken fading for collapsed blocks:

![Screenshot from 2023-07-25 13-28-41](https://github.com/neo4j-documentation/docs-ui/assets/114478074/44401f20-bcc5-44a0-a973-3b80a72484c6)
