### PR TITLE
Add option to disable feedback

### DIFF
--- a/preview-src/feedback-disabled.adoc
+++ b/preview-src/feedback-disabled.adoc
@@ -1,0 +1,5 @@
+= Feedback disabled
+:page-disablefeedback: true
+
+This page has the header attribute `:page-disablefeedback: true` set to disable the feedback popup.
+

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -178,6 +178,9 @@ page:
     - content: Examples
       url: example.html
       urlType: internal
+    - content: Feedback disabled
+      url: feedback-disabled.html
+      urlType: internal
     - content: Docs roles
       url: docs-roles.html
       urlType: internal

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -98,6 +98,8 @@ If you typed the URL of this page manually, please double check that you entered
 {{#if (eq page.layout 'training')}}
   {{> training-help}}
 {{else}}
-  {{> feedback}}
+  {{#unless page.attributes.disablefeedback}}
+    {{> feedback}}
+  {{/unless}}
 {{/if}}
 </article>


### PR DESCRIPTION
To disable feedback for a component or module, add an asciidoc attribute to the playbook or antora.yml: `page-disablefeedback: true`

To disable feedback on a specific page, add a header attribute to the page: `:page-disablefeedback: true`