### PR TITLE
Leave alone color of code blocks within admonitions

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -357,11 +357,6 @@ body {
   border-left-color: var(--color-red-600);
 }
 
-.doc .admonitionblock.warning pre {
-  background-color: var(--color-red-100);
-  color: var(--color-red-700);
-}
-
 .doc .admonitionblock.warning a.btn {
   background-color: var(--color-red-600);
 }
@@ -388,11 +383,6 @@ body {
   background-color: var(--color-orange-600);
 }
 
-.doc .admonitionblock.caution pre {
-  background-color: var(--color-orange-100);
-  color: var(--color-orange-700);
-}
-
 .doc .admonitionblock.tip {
   background-color: var(--color-blue-200);
   color: var(--color-blue-900);
@@ -409,11 +399,6 @@ body {
 
 .doc .admonitionblock.tip a.btn {
   background-color: var(--color-blue-600);
-}
-
-.doc .admonitionblock.tip pre {
-  background-color: var(--color-blue-100);
-  color: var(--color-blue-700);
 }
 
 .doc .admonitionblock.note {


### PR DESCRIPTION
(The background is anyway overwritten by the background of the child elements.)

After
![Screenshot from 2023-08-02 11-07-18](https://github.com/neo4j-documentation/docs-ui/assets/114478074/3717e495-4f6a-4abe-9850-a2c877aeceb6)

Before
![Screenshot from 2023-08-02 11-07-07](https://github.com/neo4j-documentation/docs-ui/assets/114478074/f4cba1b7-fc8d-4ab1-a08f-60bf21738618)