### PR TITLE
Improve `details` style.

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1267,6 +1267,8 @@ body {
   font-weight: bold;
 }
 
-.doc details div.content {
-  margin: 0.5rem 0 0 1.5rem;
+.doc details > div.content {
+  margin: 0.5rem 0 0 0.25rem;
+  border-left: 1px dashed var(--color-grey-300);
+  padding-left: 1rem;
 }


### PR DESCRIPTION
Adds a border to the left of a collapsed-expanded section to delimit its content.

Before
![before](https://github.com/neo4j-documentation/docs-ui/assets/114478074/fa0491b8-3729-438f-89d5-b7d91e1efcb7)

After
![after](https://github.com/neo4j-documentation/docs-ui/assets/114478074/80985c6e-c5fa-4074-90f4-c8bffccaa5bd)