### PR TITLE
Improve feedback widget

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,5 +11,8 @@
     "brace-style": ["warn", "1tbs", { "allowSingleLine": true }],
     "max-len": [1, 160, 2],
     "spaced-comment": "off"
+  },
+  "env": {
+    "browser": true
   }
 }

--- a/src/css/feedback.css
+++ b/src/css/feedback.css
@@ -11,7 +11,7 @@
   font-size: 0.8rem;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   z-index: 1000;
-  height: var(--feedback-height);
+  /*height: var(--feedback-height);*/
 }
 
 .feedback.negative {

--- a/src/css/feedback.css
+++ b/src/css/feedback.css
@@ -1,7 +1,7 @@
 .feedback {
   position: fixed;
   bottom: 0;
-  right: 2rem;
+  left: 2rem;
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0.25rem;
   background: var(--feedback-background-color);

--- a/src/css/feedback.css
+++ b/src/css/feedback.css
@@ -11,7 +11,6 @@
   font-size: 0.8rem;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   z-index: 1000;
-  /*height: var(--feedback-height);*/
 }
 
 .feedback.negative {
@@ -75,6 +74,10 @@
   font-size: 0.8rem;
 }
 
+.feedback div.more-information {
+  margin: 10px 0;
+}
+
 .feedback textarea {
   border-radius: 0.25rem;
   border: 1px solid var(--color-blue-300);
@@ -106,6 +109,7 @@
   font-weight: 600;
   margin-right: 0.5rem;
   margin-bottom: 1rem;
+  cursor: pointer;
 }
 
 .feedback .primary:focus,
@@ -150,6 +154,10 @@
 
 .feedback .thank-you-negative p {
   margin-bottom: 0.5rem;
+}
+
+.feedback .error {
+  font-size: 0.8rem;
 }
 
 @media all and (max-width: 1024px) {

--- a/src/css/feedback.css
+++ b/src/css/feedback.css
@@ -1,16 +1,17 @@
 .feedback {
   position: fixed;
   bottom: 0;
-  left: 2rem;
+  left: 1rem;
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0.25rem;
   background: var(--feedback-background-color);
   color: var(--feedback-color);
   padding: 0.5rem 1rem;
-  width: 320px;
+  width: calc(var(--nav-width) - 2rem);
   font-size: 0.8rem;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   z-index: 1000;
+  height: var(--feedback-height);
 }
 
 .feedback.negative {
@@ -159,7 +160,7 @@
     max-width: var(--doc-max-width);
     min-width: 0;
     right: auto;
-    width: auto;
+    width: calc(var(--nav-width) - 2rem);
     box-shadow: none;
     margin-bottom: 2rem;
   }

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -393,7 +393,7 @@
   --doc-max-width: calc(720 / var(--rem-base) * 1rem);
   --doc-max-width--desktop: calc(980 / var(--rem-base) * 1rem);
   --cheat-sheet-max-width--desktop: calc(1100 / var(--rem-base) * 1rem);
-  --feedback-height: 2.5rem;
+  --feedback-height: 2.75rem;
 
   /* stacking */
   --z-index-nav: 1;

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -378,8 +378,9 @@
   --nav-panel-height: calc(var(--nav-height) - var(--drawer-height));
   --nav-panel-height--desktop:
     calc(
-      var(--nav-height--desktop) - var(--drawer-height)
-    );
+      var(--nav-height--desktop) - var(--drawer-height) - var(--feedback-height) - 1rem
+    );  /* 1rem is feedback padding */
+
   --nav-width: 18rem;
   --toc-top: calc(var(--body-top) + var(--toolbar-height));
   --kb-metadata-top: calc(var(--body-top) + var(--toolbar-height));
@@ -392,6 +393,7 @@
   --doc-max-width: calc(720 / var(--rem-base) * 1rem);
   --doc-max-width--desktop: calc(980 / var(--rem-base) * 1rem);
   --cheat-sheet-max-width--desktop: calc(1100 / var(--rem-base) * 1rem);
+  --feedback-height: 2.5rem;
 
   /* stacking */
   --z-index-nav: 1;

--- a/src/js/11-feedback.js
+++ b/src/js/11-feedback.js
@@ -96,7 +96,7 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
       e.preventDefault()
       sendRequest({ helpful: true }) // get positive feedback even if thet bail out before completion
       //localStorage.removeItem('userJourney')
-      reset()
+      setTimeout(() => { fadeOut(feedback, 50) }, 2000)
     })
 
     feedback.querySelector('.primary').addEventListener('click', function (e) {

--- a/src/js/11-feedback.js
+++ b/src/js/11-feedback.js
@@ -7,9 +7,9 @@ const { getCookie } = require('./modules/cookies')
   let journey = JSON.parse(localStorage.getItem('userJourney'))
   if (journey == null) journey = []
   journey.push({
-    'url': window.location.href,
-    'title': document.title,
-    'landTime': Math.round(Date.now()/1000),
+    url: window.location.href,
+    title: document.title,
+    landTime: Math.round(Date.now() / 1000),
   })
   localStorage.setItem('userJourney', JSON.stringify(journey))
 
@@ -99,12 +99,12 @@ const { getCookie } = require('./modules/cookies')
       var moreInformation = feedback.querySelector('textarea[name="more-information"]').value
 
       sendRequest({
-        'helpful': true,
-        'moreInformation': moreInformation,
+        helpful: true,
+        moreInformation: moreInformation,
       })
       localStorage.removeItem('userJourney')
       feedback.innerHTML = '<div class="header thank-you-positive"><p><strong>Thank you for your feedback!</strong></p></div>'
-      setTimeout(() => {fadeOut(feedback)}, 2000)
+      setTimeout(() => { fadeOut(feedback) }, 2000)
 
       if (window.mixpanel) {
         window.mixpanel.track('DOCS_FEEDBACK_POSITIVE', {
@@ -181,13 +181,13 @@ const { getCookie } = require('./modules/cookies')
       var moreInformation = feedback.querySelector('textarea[name="more-information"]').value
 
       sendRequest({
-        'helpful': false,
-        'reason': reason,
-        'moreInformation': moreInformation,
+        helpful: false,
+        reason: reason,
+        moreInformation: moreInformation,
       })
       feedback.innerHTML = thankyou
       localStorage.removeItem('userJourney')
-      setTimeout(() => {fadeOut(feedback)}, 2000)
+      setTimeout(() => { fadeOut(feedback) }, 2000)
 
       if (window.mixpanel) {
         window.mixpanel.track('DOCS_FEEDBACK_POSITIVE', {
@@ -261,15 +261,15 @@ const { getCookie } = require('./modules/cookies')
   reset()
 })()
 
-function fadeOut(element) {
-  var op = 1;  // initial opacity
+function fadeOut (element) {
+  var op = 1 // initial opacity
   var timer = setInterval(function () {
-    if (op <= 0.1){
-        clearInterval(timer);
-        element.style.display = 'none';
+    if (op <= 0.1) {
+      clearInterval(timer)
+      element.style.display = 'none'
     }
-    element.style.opacity = op;
-    element.style.filter = 'alpha(opacity=' + op * 100 + ")";
-    op -= op * 0.1;
-  }, 50);
+    element.style.opacity = op
+    element.style.filter = 'alpha(opacity=' + op * 100 + ')'
+    op -= op * 0.1
+  }, 50)
 }

--- a/src/js/11-feedback.js
+++ b/src/js/11-feedback.js
@@ -5,7 +5,7 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
 ;(function () {
   'use strict'
 
-  let updateUserJourney = function() {
+  const updateUserJourney = function () {
     var journey = JSON.parse(localStorage.getItem('userJourney'))
     if (journey == null) journey = []
     journey.push({

--- a/src/js/11-feedback.js
+++ b/src/js/11-feedback.js
@@ -98,7 +98,6 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
     feedback.querySelector('.cancel').addEventListener('click', function (e) {
       e.preventDefault()
       sendRequest({ helpful: true }) // get positive feedback even if thet bail out before completion
-      //localStorage.removeItem('userJourney')
       setTimeout(() => { fadeOut(feedback, 50) }, 0)
     })
 
@@ -111,7 +110,6 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
         helpful: true,
         moreInformation: moreInformation,
       })
-      //localStorage.removeItem('userJourney')
       feedback.innerHTML = '<div class="header thank-you-positive"><p><strong>Thank you for your feedback!</strong></p></div>'
       setTimeout(() => { fadeOut(feedback, 50) }, 2000)
 
@@ -191,10 +189,6 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
         error.innerHTML = 'Please elaborate on your feedback.'
         feedback.querySelector('div[class="more-information"]')
           .insertAdjacentElement('afterend', error)
-        /*setIntervalX(function() {  // fadeOut is async, so the element never comes back
-          fadeOut(moreInformation, 50);
-          moreInformation.style.display = null
-        }, 1000, 1);*/
         return
       }
 
@@ -208,7 +202,6 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
         moreInformation: moreInformation.value,
       })
       feedback.innerHTML = thankyou
-      //localStorage.removeItem('userJourney')
 
       feedback.classList.remove('negative')
       feedback.classList.add('positive')
@@ -222,28 +215,6 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
         })
       }
     })
-
-    /*feedback.querySelector('.secondary').addEventListener('click', function (e) {
-      e.preventDefault()
-
-      var reason = feedback.querySelector('input[name="specific"]:checked').value
-      var moreInformation = feedback.querySelector('textarea[name="more-information"]').value
-
-      sendRequest({
-        'helpful': false,
-        'reason': reason,
-        'moreInformation': moreInformation,
-      })
-      feedback.innerHTML = thankyou
-
-      if (window.mixpanel) {
-        window.mixpanel.track('DOCS_FEEDBACK_SKIP', {
-          pathname: window.location.origin + window.location.pathname,
-          search: window.location.search,
-          hash: window.location.hash,
-        })
-      }
-    })*/
   }
 
   var reset = function () {
@@ -299,15 +270,3 @@ function fadeOut (element, speed) {
   // enlarge navigation to fill hole left by feedback widget faded out
   document.documentElement.style.setProperty('--feedback-height', '0rem')
 }
-
-/*function setIntervalX(callback, delay, repetitions) {
-  var x = 0;
-  var intervalID = window.setInterval(function () {
-
-     callback();
-
-     if (++x === repetitions) {
-         window.clearInterval(intervalID);
-     }
-  }, delay);
-}*/

--- a/src/js/11-feedback.js
+++ b/src/js/11-feedback.js
@@ -5,8 +5,8 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
 ;(function () {
   'use strict'
 
-  /*let updateUserJourney = function() {
-    JSON.parse(localStorage.getItem('userJourney'))
+  let updateUserJourney = function() {
+    var journey = JSON.parse(localStorage.getItem('userJourney'))
     if (journey == null) journey = []
     journey.push({
       url: window.location.href,
@@ -15,7 +15,7 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
     })
     localStorage.setItem('userJourney', JSON.stringify(journey))
   }
-  updateUserJourney()*/
+  updateUserJourney()
 
   var feedback = document.querySelector('.feedback')
   if (!feedback) return
@@ -57,7 +57,10 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
       body += '&' + paramKey + '=' + encodeURIComponent(paramVal)
     }
 
-    //body += '&userJourney=' + encodeURIComponent(localStorage.getItem('userJourney').toString())
+    var userJourney = localStorage.getItem('userJourney')
+    if (JSON.parse(userJourney).length > 1) {
+      body += '&userJourney=' + encodeURIComponent(userJourney)
+    }
 
     //console.log(body)
     fetch(URL, {
@@ -67,7 +70,7 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
       },
       body: body,
     })
-    //localStorage.removeItem('userJourney')
+    localStorage.removeItem('userJourney')
   }
 
   var isHelpful = function () {

--- a/src/js/11-feedback.js
+++ b/src/js/11-feedback.js
@@ -96,7 +96,7 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
       e.preventDefault()
       sendRequest({ helpful: true }) // get positive feedback even if thet bail out before completion
       //localStorage.removeItem('userJourney')
-      setTimeout(() => { fadeOut(feedback, 50) }, 2000)
+      setTimeout(() => { fadeOut(feedback, 50) }, 0)
     })
 
     feedback.querySelector('.primary').addEventListener('click', function (e) {

--- a/src/js/11-feedback.js
+++ b/src/js/11-feedback.js
@@ -5,14 +5,17 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
 ;(function () {
   'use strict'
 
-  let journey = JSON.parse(localStorage.getItem('userJourney'))
-  if (journey == null) journey = []
-  journey.push({
-    url: window.location.href,
-    title: document.title,
-    landTime: Math.round(Date.now() / 1000),
-  })
-  localStorage.setItem('userJourney', JSON.stringify(journey))
+  /*let updateUserJourney = function() {
+    JSON.parse(localStorage.getItem('userJourney'))
+    if (journey == null) journey = []
+    journey.push({
+      url: window.location.href,
+      title: document.title,
+      landTime: Math.round(Date.now() / 1000),
+    })
+    localStorage.setItem('userJourney', JSON.stringify(journey))
+  }
+  updateUserJourney()*/
 
   var feedback = document.querySelector('.feedback')
   if (!feedback) return
@@ -54,16 +57,17 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
       body += '&' + paramKey + '=' + encodeURIComponent(paramVal)
     }
 
-    body += '&userJourney=' + encodeURIComponent(localStorage.getItem('userJourney').toString())
+    //body += '&userJourney=' + encodeURIComponent(localStorage.getItem('userJourney').toString())
 
-    console.log(body)
-    /*fetch(URL, {
+    //console.log(body)
+    fetch(URL, {
       method: 'post',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: body,
-    })*/
+    })
+    //localStorage.removeItem('userJourney')
   }
 
   var isHelpful = function () {
@@ -91,7 +95,7 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
     feedback.querySelector('.cancel').addEventListener('click', function (e) {
       e.preventDefault()
       sendRequest({ helpful: true }) // get positive feedback even if thet bail out before completion
-      localStorage.removeItem('userJourney')
+      //localStorage.removeItem('userJourney')
       reset()
     })
 
@@ -104,7 +108,7 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
         helpful: true,
         moreInformation: moreInformation,
       })
-      localStorage.removeItem('userJourney')
+      //localStorage.removeItem('userJourney')
       feedback.innerHTML = '<div class="header thank-you-positive"><p><strong>Thank you for your feedback!</strong></p></div>'
       setTimeout(() => { fadeOut(feedback, 50) }, 2000)
 
@@ -201,7 +205,7 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
         moreInformation: moreInformation.value,
       })
       feedback.innerHTML = thankyou
-      localStorage.removeItem('userJourney')
+      //localStorage.removeItem('userJourney')
 
       feedback.classList.remove('negative')
       feedback.classList.add('positive')

--- a/src/js/11-feedback.js
+++ b/src/js/11-feedback.js
@@ -99,6 +99,14 @@ const URL = 'https://uglfznxroe.execute-api.us-east-1.amazonaws.com/dev/Feedback
       e.preventDefault()
       sendRequest({ helpful: true }) // get positive feedback even if thet bail out before completion
       setTimeout(() => { fadeOut(feedback, 50) }, 0)
+
+      if (window.mixpanel) {
+        window.mixpanel.track('DOCS_FEEDBACK_POSITIVE', {
+          pathname: window.location.origin + window.location.pathname,
+          search: window.location.search,
+          hash: window.location.hash,
+        })
+      }
     })
 
     feedback.querySelector('.primary').addEventListener('click', function (e) {

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -97,9 +97,5 @@ If you typed the URL of this page manually, please double check that you entered
 {{> comments}}
 {{#if (eq page.layout 'training')}}
   {{> training-help}}
-{{else}}
-  {{#unless page.attributes.disablefeedback}}
-    {{> feedback}}
-  {{/unless}}
 {{/if}}
 </article>

--- a/src/partials/feedback.hbs
+++ b/src/partials/feedback.hbs
@@ -1,4 +1,4 @@
-<div class="feedback">
+<div class="feedback" style="height: var(--feedback-height);">
     <div class="header question">
         <p><strong>Is this page helpful?</strong></p>
 

--- a/src/partials/feedback.hbs
+++ b/src/partials/feedback.hbs
@@ -1,6 +1,6 @@
 <div class="feedback">
     <div class="header question">
-        <p><strong>Was this page helpful?</strong></p>
+        <p><strong>Helpful?</strong></p>
 
         <svg width="22px" height="22px" viewBox="0 0 22 22" role="button" class="no" aria-label="No, this page isn't helpful">
             <path

--- a/src/partials/feedback.hbs
+++ b/src/partials/feedback.hbs
@@ -1,6 +1,6 @@
 <div class="feedback">
     <div class="header question">
-        <p><strong>Helpful?</strong></p>
+        <p><strong>Is this page helpful?</strong></p>
 
         <svg width="22px" height="22px" viewBox="0 0 22 22" role="button" class="no" aria-label="No, this page isn't helpful">
             <path

--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -5,6 +5,7 @@
         {{> nav-selectors}}
       </div>
       {{> nav-menu}}
+      {{> feedback}}
     </div>
   </aside>
 </div>


### PR DESCRIPTION
- widget moved to the left, and is part of the html output rather than being a floating js object. Because the right ToC has `position: sticky` and scrolls itself as you progress through a page, I was unable to leave the feedback on the right _and_ avoid it shadowing some content. I've made the nav on the left slightly smaller so people can't think there's anything underneath the feedback. It gets expanded to full height when the feedback vanishes.
- after leaving feedback, politely thanks you and vanishes within a couple seconds
- you _can't_ leave negative feedback without adding a message
- you _can_ leave a message to a positive feedback (but may also leave it empty)
- the user journey through docs pages is registered and submitted as part of their feedback
- taken away the `Edit this page` links, and improved style/wording overall

----

Depends on 

https://github.com/neo4j-labs/neo4j-labs.github.io/pull/3
https://github.com/neo4j-contrib/dx-feedback-form/pull/2