### PR TITLE
Update highlightjs-cypher to 1.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gulp-vinyl-zip": "~2.2",
     "handlebars": "~4.7",
     "highlight.js": "^10.7",
-    "highlightjs-cypher": "^1.1",
+    "highlightjs-cypher": "^1.2",
     "husky": "^4.3.0",
     "js-yaml": "~3.13",
     "medium-zoom": "^1.0.6",


### PR DESCRIPTION
Contains updates for cypher syntax highlighting for v5 https://github.com/highlightjs/highlightjs-cypher/pull/18