### PR TITLE
Improve label behavior with table of contents

### DIFF
--- a/src/css/labels.css
+++ b/src/css/labels.css
@@ -9,6 +9,14 @@
   font-style: normal;
 }
 
+h2 > span.label,
+h3 > span.label,
+h4 > span.label,
+h5 > span.label,
+h6 > span.label {
+  float: right;
+}
+
 .tableblock .label {
   margin-top: 0.2rem;
 }

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -21,8 +21,9 @@
   var list = headings.reduce(function (accum, heading) {
     var link = document.createElement('a')
     var headingWithoutLabels = heading.cloneNode(true)
-    if (headingWithoutLabels.querySelector('span.label') != null)
+    if (headingWithoutLabels.querySelector('span.label') != null) {
       headingWithoutLabels.removeChild(headingWithoutLabels.querySelector('span.label'))
+    }
     link.textContent = headingWithoutLabels.textContent
     links[(link.href = '#' + heading.id)] = link
     var listItem = document.createElement('li')

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -20,7 +20,10 @@
   var links = {}
   var list = headings.reduce(function (accum, heading) {
     var link = document.createElement('a')
-    link.textContent = heading.textContent
+    var headingWithoutLabels = heading.cloneNode(true)
+    if (headingWithoutLabels.querySelector('span.label') != null)
+      headingWithoutLabels.removeChild(headingWithoutLabels.querySelector('span.label'))
+    link.textContent = headingWithoutLabels.textContent
     links[(link.href = '#' + heading.id)] = link
     var listItem = document.createElement('li')
     listItem.dataset.level = parseInt(heading.nodeName.slice(1)) - 1

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -20,11 +20,8 @@
   var links = {}
   var list = headings.reduce(function (accum, heading) {
     var link = document.createElement('a')
-    var headingWithoutLabels = heading.cloneNode(true)
-    if (headingWithoutLabels.querySelector('span.label') != null) {
-      headingWithoutLabels.removeChild(headingWithoutLabels.querySelector('span.label'))
-    }
-    link.textContent = headingWithoutLabels.textContent
+    var headingTextWithoutLabels = Array.from(heading.childNodes).filter((el) => el.nodeType === Node.TEXT_NODE).map((el) => el.textContent).join(' ').trim()
+    link.textContent = headingTextWithoutLabels
     links[(link.href = '#' + heading.id)] = link
     var listItem = document.createElement('li')
     listItem.dataset.level = parseInt(heading.nodeName.slice(1)) - 1


### PR DESCRIPTION
This is how it looks now, with label close to heading and the label content going into the ToC entry
![Screenshot from 2024-01-17 12-12-47](https://github.com/neo4j-documentation/docs-ui/assets/114478074/0960d317-7a7a-4de6-a25a-36e644f03be3)

After the changes, the same asciidoc (with an explicit anchor) renders to
![with-anchor](https://github.com/neo4j-documentation/docs-ui/assets/114478074/50fec6a1-1a7b-4ede-b4df-8337ca98486c)

Notice that if the anchor is omitted, and antora autogenerates the heading id, the label ends up in the anchor
![without-anchor](https://github.com/neo4j-documentation/docs-ui/assets/114478074/e230ff26-7e02-4ac3-82ed-81585cd80328)

