### PR TITLE
Remove pipe from replaced characters in callouts

### DIFF
--- a/src/js/06-code.js
+++ b/src/js/06-code.js
@@ -36,7 +36,7 @@ import { createElement } from './modules/dom'
 })()
 
 var cleanCallouts = function (code) {
-  return code.replace(/[ |\t]+\n/g, '\n').trimEnd()
+  return code.replace(/[ \t]+\n/g, '\n').trimEnd()
 }
 
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
The pipe is excluded from content when copied through the Copy icon, causing it to be skipped when a code block like in the [Kafka docs](https://neo4j.com/docs/kafka/quickstart-connect/#_run_with_docker) is copied.

This PR seems to fix this behaviour, but I would like to understand what was the rationale for exclusion before applying it.
This change was introduced in https://github.com/neo4j-documentation/docs-ui/pull/204, but from the discussion I can't understand why the pipe was excluded as well.