### PR TITLE
Reduce tab-size

### DIFF
--- a/src/css/code.css
+++ b/src/css/code.css
@@ -362,6 +362,7 @@
   .code-walkthrough .doc .listingblock code {
     box-shadow: none;
     border: 0 none !important;
+    tab-size: 2;
   }
 
   .code-walkthrough .toc {


### PR DESCRIPTION
Reduces the size of tabs in code blocks, currently looks like 8 spaces ([example](https://neo4j.com/labs/genai-ecosystem/spring-ai/))