### PR TITLE
Avoid autoscroll when changing tab in tabbed example.

### DIFF
--- a/src/js/06-code.js
+++ b/src/js/06-code.js
@@ -284,22 +284,6 @@ document.addEventListener('DOMContentLoaded', function () {
         })
     })
 
-    var toolbarOffset = 0
-    var toolbar = document.querySelector('.toolbar')
-    if (toolbar.offsetHeight) {
-      toolbarOffset = toolbar.offsetHeight
-    }
-    var offset = document.querySelector('.navbar').offsetHeight + toolbarOffset + 20
-
-    var bodyRect = document.body.getBoundingClientRect().top
-    var elementRect = tab.getBoundingClientRect().top
-    var elementPosition = elementRect - bodyRect
-    var offsetPosition = elementPosition - offset
-
-    window.scrollTo({
-      top: offsetPosition,
-      behavior: 'smooth',
-    })
   }
 
   // Tabbed code

--- a/src/js/06-code.js
+++ b/src/js/06-code.js
@@ -283,7 +283,6 @@ document.addEventListener('DOMContentLoaded', function () {
           el.classList.add(tabActive)
         })
     })
-
   }
 
   // Tabbed code

--- a/src/js/08-tabs-block.js
+++ b/src/js/08-tabs-block.js
@@ -63,23 +63,6 @@ document.addEventListener('DOMContentLoaded', function () {
         })
     })
 
-    var toolbarOffset = 0
-    var toolbar = document.querySelector('.toolbar')
-    if (toolbar.offsetHeight) {
-      toolbarOffset = toolbar.offsetHeight
-    }
-    var offset = document.querySelector('.navbar').offsetHeight + toolbarOffset + 20
-
-    var bodyRect = document.body.getBoundingClientRect().top
-    var elementRect = tab.getBoundingClientRect().top
-    var elementPosition = elementRect - bodyRect
-    var offsetPosition = elementPosition - offset
-
-    window.scrollTo({
-      top: offsetPosition,
-      behavior: 'smooth',
-    })
-
     if (sessionStorageAvailable) {
       window.sessionStorage.setItem('code_example_language', lang)
     }


### PR DESCRIPTION
I think it's a bad UX if the page moves unexpectedly. When looking at examples, people may want to look at them together with the text leading to it, and they have to manually scroll back up to.

Before
![scroll](https://github.com/neo4j-documentation/docs-ui/assets/114478074/ed4a6234-6209-4244-8646-6ac463521162)

After
![no-scroll](https://github.com/neo4j-documentation/docs-ui/assets/114478074/9541bdca-bf8a-40a2-83f3-0db04451edcb)

Question for @adam-cowley and @recrwplay , if you remember from 4 years ago: why do we have both `[.tabs]` and `[.tabbed-example]`? 

I believe we are actively only using `[.tabbed-example]`. If that's the case, can I declutter and entirely remove the `[.tabs]` bit?