### PR TITLE
Fix code highlighting

### DIFF
--- a/src/js/vendor/highlight.js
+++ b/src/js/vendor/highlight.js
@@ -133,7 +133,7 @@
   // Apply line highlighting to lines marked with `// marked-line`
   // eat away line breaks or they would be doubled by the div
   hljs.addPlugin({
-    'after:highlightElement': ({ el, result, text }) => {
+    'after:highlight': (result) => {
       result.value = result.value.replaceAll(/^(\s*)(.+?)\s*<span class="hljs-comment">.*?\bmark-line\b.*?<\/span>\n?/mg, '<div class="highlight-line">$1$2</div>')
     }
   });


### PR DESCRIPTION
There's been an intermittent problem where `after:highlightElement` would not always fire and thus leave the `mark-line` comments untouched. This change hopefully fixes that.