### PR TITLE
Labels: make deprecated labels yellow, discontinued red.

### DIFF
--- a/src/css/labels.css
+++ b/src/css/labels.css
@@ -185,10 +185,14 @@ span.label--warning {
   color: var(--warning-background-color);
 }
 
-span.label--deprecated,
 span.label--discontinued {
-  background: var(--deprecated-color);
-  color: var(--deprecated-background-color);
+  background: var(--discontinued-color);
+  color: var(--discontinued-background-color);
+}
+
+span.label--deprecated {
+  background: var(--deprecated-background-color);
+  color: var(--deprecated-color);
 }
 
 span.label--unix,

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -348,8 +348,10 @@
   --kbd-border-color: rgba(var(--colors-neutral-40));
 
   /* roles */
-  --deprecated-color: rgba(var(--theme-light-palette-danger-bg-strong));
-  --deprecated-background-color: rgba(var(--theme-light-palette-danger-bg-weak));
+  --deprecated-color: rgba(var(--colors-lemon-80));
+  --deprecated-background-color: rgba(var(--colors-lemon-30));
+  --discontinued-color: rgba(var(--theme-light-palette-danger-bg-strong));
+  --discontinued-background-color: rgba(var(--theme-light-palette-danger-bg-weak));
   --not-on-aura-color: var(--warning-background-color);
   --not-on-aura-background-color: var(--warning-color);
   --aura-db-enterprise-color: rgba(var(--colors-baltic-10));


### PR DESCRIPTION
To create visual difference between removals and deprecations. 

Result:
![Screenshot from 2024-07-15 11-58-53](https://github.com/user-attachments/assets/065299c1-4567-4fb2-8ecb-6305f0cdc682)

Spawned #241.