### PR TITLE
Enlarge docs header dropdown

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -339,7 +339,7 @@ body {
   }
 
   .navbar-item .navbar-dropdown {
-    max-width: 320px;
+    max-width: 660px;
   }
 
   .navbar-item.is-hoverable:hover .navbar-dropdown {

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -327,7 +327,8 @@ body {
   }
 
   .navbar-item.docs .navbar-dropdown {
-    width: 320px;
+    width: 660px;
+    max-width: 660px;
   }
 
   .navbar-item.labs .navbar-dropdown {
@@ -339,7 +340,7 @@ body {
   }
 
   .navbar-item .navbar-dropdown {
-    max-width: 660px;
+    max-width: 320px;
   }
 
   .navbar-item.is-hoverable:hover .navbar-dropdown {


### PR DESCRIPTION
Before, all items are not visible in docs menu item  
![Screenshot from 2024-07-18 19-38-02](https://github.com/user-attachments/assets/528f9e0d-4e26-49b9-a5a7-67bc42dc5e29)

After
![Screenshot from 2024-07-18 19-37-13](https://github.com/user-attachments/assets/2d6f3488-8824-47a4-980f-2804c9b4f48e)

