### PR TITLE
Make  header docs dropdown fully visible at all widths

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -406,7 +406,7 @@ body {
     border-radius: 0 0 0.25rem 0.25rem;
     display: none;
     top: 100%;
-    right: 0;
+    left: 0;
     min-width: 100%;
     position: absolute;
   }


### PR DESCRIPTION
From viewport widths less than ~1300px down to the breakpoint at 1024px when the TOC is removed and accessed via the burger icon the Docs drop-down menu is partly off-screen because of the increased width.

Aligning dropdowns to the left prevents part of the docs dropdown from disappearing off the left of the viewport.