### PR TITLE
Remove toc sidebar when page-toclevels is -1

### DIFF
--- a/preview-src/tables-no-toc.adoc
+++ b/preview-src/tables-no-toc.adoc
@@ -1,0 +1,281 @@
+= Tables with no in-page Contents
+:nofooter:
+:page-ogtitle: This page uses the page-ogtitle attribute to generate a custom title for SEO meta
+:page-toclevels: -1
+
+.No striping
+// Alternative to stripes attributes is
+// setting role "stripes-none" as [.stripes-none,cols="1,2"].
+[stripes=none,cols="1,2"]
+|===
+| Name | Description
+
+| Asciidoctor
+| *Awesome* way to write documentation
+
+| Micronaut
+| Low resource usage and fast startup micro services
+|===
+
+.All rows
+// Alternative to stripes attributes is
+// setting role "stripes-all" as [.stripes-all,cols="1,2"].
+[stripes=all,cols="1,2"]
+|===
+| Name | Description
+
+| Asciidoctor
+| *Awesome* way to write documentation
+
+| Micronaut
+| Low resource usage and fast startup micro services
+|===
+
+.Odd rows
+// Alternative to stripes attributes is
+// setting role "stripes-odd" as [.stripes-odd,cols="1,2"].
+[stripes=odd,cols="1,2"]
+|===
+| Name | Description
+
+| Asciidoctor
+| *Awesome* way to write documentation
+
+| Micronaut
+| Low resource usage and fast startup micro services
+|===
+
+.Even rows (default)
+// Alternative to stripes attributes is
+// setting role "stripes-even" as [.stripes-even,cols="1,2"].
+[stripes=even,cols="1,2"]
+|===
+| Name | Description
+
+| Asciidoctor
+| *Awesome* way to write documentation
+
+| Micronaut
+| Low resource usage and fast startup micro services
+|===
+
+.Hover
+[stripes=hover,cols="1,2"]
+|===
+| Name | Description
+
+| Asciidoctor
+| *Awesome* way to write documentation
+
+| Micronaut
+| Low resource usage and fast startup micro services
+|===
+
+.No header
+[cols="1,2"]
+|===
+| Asciidoctor
+| *Awesome* way to write documentation
+
+| Micronaut
+| Low resource usage and fast startup micro services
+|===
+
+.Table with top and bottom frame (topbot)
+[frame="topbot"]
+|===
+| Name | Description
+
+| Asciidoctor
+| Awesome way to write documentation
+
+|===
+
+
+.Table with no frame (none)
+[frame="none"]
+|===
+| Name | Description
+
+| Asciidoctor
+| Awesome way to write documentation
+
+|===
+
+
+.Table with only sides frame (sides)
+[frame="sides"]
+|===
+| Name | Description
+
+| Asciidoctor
+| Awesome way to write documentation
+
+|===
+
+
+.Table with default frame (all)
+[frame="all"]
+|===
+| Name | Description
+
+| Asciidoctor
+| Awesome way to write documentation
+
+|===
+
+.Table with no grid (none)
+[grid="none", frame="none"]
+|===
+| Name | Description
+
+| Asciidoctor
+| Awesome way to write documentation
+
+|===
+
+.Table with only columns grid (cols)
+[grid="cols", frame="none"]
+|===
+| Name | Description
+
+| Asciidoctor
+| Awesome way to write documentation
+
+|===
+
+.Table with only rows grid (rows)
+[grid="rows", frame="none"]
+|===
+| Name | Description
+
+| Asciidoctor
+| Awesome way to write documentation
+
+|===
+
+.Table with default rows and columns grid (all)
+[grid="all", frame="none"]
+|===
+| Name | Description
+
+| Asciidoctor
+| Awesome way to write documentation
+
+|===
+
+== Setup and Cypher Refresher
+
+[frame="none", cols="^.^,<.^"]
+|===
+a|image::sandbox.png[Neo4j Sandbox,width=500,align=center]
+a|
+Neo4j Sandbox is a hosted Neo4j tool that allows you to run private instances of Neo4j without having to install Neo4j locally. You can choose Neo4j Sandbox usecases that come pre-loaded with datasets and your Neo4j Sandbox instances can be accessed over the internet, making them useful for building sample applications. While Neo4j Browser is the primary way to interact with Neo4j instances hosted by Neo4j Sandbox, for this course you will also connect your sandbox instance to a simple web application.
+|===
+
+== Breaking long text
+
+Long parameter, var, or option names shouldn't wrap
+
+.Results
+[opts="header",cols="1,1,6"]
+|===
+| Name                   | Type      | Description
+| nodes                  | int       | The number of nodes considered.
+| writeProperty          | string    | The property name written back to.
+| createMillis           | int       | Milliseconds for loading data.
+| computeMillis          | int       | Milliseconds for running the algorithm.
+| writeMillis            | int       | Milliseconds for writing result data back.
+| centralityDistribution | Map       | Map containing min, max, mean as well as p50, p75, p90, p95, p99 and p999 percentile values of centrality values.
+|===
+
+In case a value or long string is used in a link but not formatted as code
+
+|===
+| text | link
+| text | link:example.com[bolt.connections,bolt.messages_received,bolt.messages_started,dbms.pool.bolt.free,*dbms.pool.bolt.total_size,*dbms.pool.bolt.total_used,*dbms.pool.bolt.used_heap,*causal_clustering.core.is_leader,*causal_clustering.core.last_leader_message,*causal_clustering.core.replication_attempt]
+|===
+
+The next table includes a large codeblock, which needs to wrap
+
+.metrics.filter
+[cols="<1s,<4"]
+|===
+|Description
+a|Specifies which metrics should be enabled by using a comma separated list of globbing patterns. Only the metrics matching the filter will be enabled. For example '*check_point*,neo4j.page_cache.evictions' will enable any checkpoint metrics and the pagecache eviction metric.
+|Valid values
+a|metrics.filter, a ',' separated list with elements of type 'A simple globbing pattern that can use '*' and '?'.'.
+|Default value
+m|*bolt.connections*,*bolt.messages_received*,*bolt.messages_started*,*dbms.pool.bolt.free,*dbms.pool.bolt.total_size,*dbms.pool.bolt.total_used,*dbms.pool.bolt.used_heap,*causal_clustering.core.is_leader,*causal_clustering.core.last_leader_message,*causal_clustering.core.replication_attempt,*causal_clustering.core.replication_fail,*check_point.duration,*check_point.total_time,*cypher.replan_events,*ids_in_use.node,*ids_in_use.property,*ids_in_use.relationship,*pool.transaction.*.total_used,*pool.transaction.*.used_heap,*pool.transaction.*.used_native,*store.size*,*transaction.active_read,*transaction.active_write,*transaction.committed*,*transaction.last_committed_tx_id,*transaction.peak_concurrent,*transaction.rollbacks*,*page_cache.hit*,*page_cache.page_faults,*page_cache.usage_ratio,*vm.file.descriptors.count,*vm.gc.time.*,*vm.heap.used,*vm.memory.buffer.direct.used,*vm.memory.pool.g1_eden_space,*vm.memory.pool.g1_old_gen,*vm.pause_time,*vm.thread*
+
+|===
+
+== Table Text Wrap
+
+Tables showing word-break behavior 
+
+=== Text, links, and inline code
+
+[opts="header",cols="1,1,1m,1,8"]
+|===
+| Name                                                          | Type        | Default                | Optional | Description
+| <<table-link-target,nodeLabels>>               | List of String    | ['*']                  | yes      | Filter the named graph using the given node labels.
+| <<table-link-target,relationshipTypes>> | List of String    | ['*']                  | yes      | Filter the named graph using the given relationship types.
+| <<table-link-target,concurrency>>              | Integer     | 4                      | yes      | The number of concurrent threads used for running the algorithm.
+|===
+
+[opts="header",cols="1,1,1m,1,8"]
+|===
+| Name                                                          | Type        | Default                | Optional | Description
+| `<<common-configuration-node-labels,nodeLabels>>`               | List of String    | ['*']                  | yes      | Filter the named graph using the given node labels.
+| `<<common-configuration-relationship-types,relationshipTypes>>` | List of String    | ['*']                  | yes      | Filter the named graph using the given relationship types.
+| `<<common-configuration-concurrency,concurrency>>`              | Integer     | 4                      | yes      | The number of concurrent threads used for running the algorithm.
+|===
+
+[opts="header",cols="1,1,1m,1,8"]
+|===
+| Name                                                          | Type        | Default                | Optional | Description
+| `nodeLabels`               | List of String    | ['*']                  | yes      | Filter the named graph using the given node labels.
+| `relationshipTypes` | List of String    | ['*']                  | yes      | Filter the named graph using the given relationship types.
+| `concurrency`            | Integer     | 4                      | yes      | The number of concurrent threads used for running the algorithm.
+|===
+
+=== Table with better column widths:
+
+[opts="header",cols="2,1,1m,1,5"]
+|===
+| Name                                                          | Type        | Default                | Optional | Description
+| <<table-link-target,nodeLabels>>               | List of String    | ['*']                  | yes      | Filter the named graph using the given node labels.
+| <<table-link-target,relationshipTypes>> | List of String    | ['*']                  | yes      | Filter the named graph using the given relationship types.
+| <<table-link-target,concurrency>>              | Integer     | 4                      | yes      | The number of concurrent threads used for running the algorithm.
+|===
+
+=== Tables with `role=no-break`:
+
+[role="no-break",opts="header",cols="1,1,1m,1,8"]
+|===
+| Name                                                          | Type        | Default                | Optional | Description
+| <<common-configuration-node-labels,nodeLabels>>               | List of String    | ['*']                  | yes      | Filter the named graph using the given node labels.
+| <<common-configuration-relationship-types,relationshipTypes>> | List of String    | ['*']                  | yes      | Filter the named graph using the given relationship types.
+| <<common-configuration-concurrency,concurrency>>              | Integer     | 4                      | yes      | The number of concurrent threads used for running the algorithm.
+|===
+
+[role="no-break",opts="header",cols="1,1,1m,1,8"]
+|===
+| Name                                                          | Type        | Default                | Optional | Description
+| `<<common-configuration-node-labels,nodeLabels>>`               | List of String    | ['*']                  | yes      | Filter the named graph using the given node labels.
+| `<<common-configuration-relationship-types,relationshipTypes>>` | List of String    | ['*']                  | yes      | Filter the named graph using the given relationship types.
+| `<<common-configuration-concurrency,concurrency>>`              | Integer     | 4                      | yes      | The number of concurrent threads used for running the algorithm.
+|===
+
+[role="no-break",opts="header",cols="1,1,1m,1,8"]
+|===
+| Name                                                          | Type        | Default                | Optional | Description
+| `nodeLabels`               | List of String    | ['*']                  | yes      | Filter the named graph using the given node labels.
+| `relationshipTypes` | List of String    | ['*']                  | yes      | Filter the named graph using the given relationship types.
+| `concurrency`             | Integer     | 4                      | yes      | The number of concurrent threads used for running the algorithm.
+|===
+
+== table link target
+
+A section for table links to point to

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -195,6 +195,9 @@ page:
     - content: Tables
       url: tables.html
       urlType: internal
+    - content: Tables (no toc)
+      url: tables-no-toc.html
+      urlType: internal
     - content: Tables (No Captions)
       url: tables-no-captions.html
       urlType: internal

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -6,7 +6,7 @@
   if (!sidebar) return
   if (document.querySelector('body.-toc')) return sidebar.parentNode.removeChild(sidebar)
   var levels = parseInt(sidebar.dataset.levels || 2)
-  if (levels < 0) return
+  if (levels < 0) return sidebar.parentNode.removeChild(sidebar) // remove the sidebar if :page-toclevels: -1
 
   var article = document.querySelector('article.doc')
   var selectors = document.querySelector('.nav-container .selectors')
@@ -14,7 +14,7 @@
   var headings
   var headingSelector = []
   for (var l = 0; l <= levels; l++) headingSelector.push(l ? '.sect' + l + '>h' + (l + 1) + '[id]' : 'h1[id].sect0')
-  if (!(headings = find(headingSelector.join(','), article)).length) return sidebar.parentNode.removeChild(sidebar)
+  if (!(headings = find(headingSelector.join(','), article)).length) return sidebar.parentNode.removeChild(sidebar) // remove sidebar if there are no headings
 
   var lastActiveFragment
   var links = {}


### PR DESCRIPTION
At narrow page widths, when the main TOC is still visible, setting `:page-toclevel: -1` results in no in-page 'Contents' being displayed, but the HTML elements are still present, taking up width.

This can produce inconsistent page appearance:
- pages with no headings use the available width
- pages with headings, but the 'Contents' section removed use the width minus the width of the `<aside>`.

Note that this change has no effect on the page layout once the `<article>` (the main page content) reaches its maximum width.