### PR TITLE
Fix nocopy and noheader behavior

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -521,7 +521,7 @@ CREATE (n:Node {id: id, test: true, str: 'ing'})
 RETURN collect(n) AS ns
 ----
 
-.noheader
+.Codeblock with role=noheader
 [source,cypher,role=noheader]
 ----
 UNWIND range(0, 100) AS id
@@ -529,7 +529,7 @@ CREATE (n:Node {id: id, test: true, str: 'ing'})
 RETURN collect(n) AS ns
 ----
 
-.nocopy
+.Codeblock with role=nocopy
 [source,cypher,role=nocopy]
 ----
 UNWIND range(0, 100) AS id
@@ -537,7 +537,15 @@ CREATE (n:Node {id: id, test: true, str: 'ing'})
 RETURN collect(n) AS ns
 ----
 
+.Codeblock with role=nocopy noheader
+[source,cypher,role=nocopy noheader]
+----
+UNWIND range(0, 100) AS id
+CREATE (n:Node {id: id, test: true, str: 'ing'})
+RETURN collect(n) AS ns
+----
 
+.Just some pre
 ....
 pom.xml
 src/

--- a/src/js/06-code.js
+++ b/src/js/06-code.js
@@ -131,7 +131,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     listingBlock.classList.add('has-header')
 
-    if (originalTitle) {
+    if (originalTitle && !listingBlock.classList.contains('noheader')) {
       listingBlock.classList.add('has-title')
       var titleDiv = document.createElement('div')
       titleDiv.className = 'code-title'
@@ -139,6 +139,8 @@ document.addEventListener('DOMContentLoaded', function () {
       originalTitle.style.display = 'none'
       headerDivs.push(titleDiv)
     }
+
+    var inset = createElement('div', 'code-inset')
 
     if (addCopyButton) {
       var copyButton = createElement('span', 'btn btn-copy fa fa-copy')
@@ -168,21 +170,12 @@ document.addEventListener('DOMContentLoaded', function () {
         }, 1000)
       })
 
-      var inset = createElement('div', 'code-inset', copyButton)
-      if (language !== 'none' && language) inset.dataset.lang = casedLang(language)
-
+      inset.appendChild(copyButton)
       inset.appendChild(copySuccess)
-
-      // if (originalTitle) {
-      //   div.insertBefore(inset, pre)
-      // } else {
-      //   pre.appendChild(inset)
-      // }
-
-      // pre.appendChild(inset)
-
-      headerDivs.push(inset)
     }
+
+    if (language !== 'none' && language) inset.dataset.lang = casedLang(language)
+    headerDivs.push(inset)
 
     var header = createElement('div', 'code-header', headerDivs)
     div.insertBefore(header, pre)


### PR DESCRIPTION
Fixes an issue where adding `role=nocopy` to a code block was also removing the header.

It is now possible to use:
- `role=nocopy` to not display the copy icon
- `role=noheader` to not display the header
- `role=nocopy noheader` to not display both