### PR TITLE
Add beta-until label

### DIFF
--- a/preview-src/docs-roles.adoc
+++ b/preview-src/docs-roles.adoc
@@ -13,6 +13,12 @@ Flags sections as Not Available on Aura, Aura DB Enterprise, Enterprise Edition,
 --
 
 
+[role=betaUntil-5.12]
+== Beta until
+
+Lorem ipsum.
+
+
 [role="label--new-5.17 label--enterprise-edition"]
 == Relationship property type constraints
 

--- a/preview-src/docs-roles.adoc
+++ b/preview-src/docs-roles.adoc
@@ -13,7 +13,7 @@ Flags sections as Not Available on Aura, Aura DB Enterprise, Enterprise Edition,
 --
 
 
-[role=betaUntil-5.12]
+[role=label--new-5.11 label--beta-until-5.12]
 == Beta until
 
 Lorem ipsum.

--- a/src/css/labels.css
+++ b/src/css/labels.css
@@ -168,7 +168,7 @@ span.label--yes {
 
 span.label--alpha,
 span.label--beta,
-span.label--betaUntil {
+span.label--beta-until {
   background: var(--alpha-beta-background-color);
   color: var(--alpha-beta-color);
 }

--- a/src/css/labels.css
+++ b/src/css/labels.css
@@ -167,7 +167,8 @@ span.label--yes {
 }
 
 span.label--alpha,
-span.label--beta {
+span.label--beta,
+span.label--betaUntil {
   background: var(--alpha-beta-background-color);
   color: var(--alpha-beta-color);
 }

--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -26,8 +26,14 @@ const prodMatrix = {
 
 // get the default product from optionMap
 const defaultProdArray = optionMap.find((prod) => prod.default === 'true')
-const defaultProd = defaultProdArray ? defaultProdArray.value : optionMap[0].value
 
+// display for 'all' products unless a differnt value is specified via attributes in source
+let defaultProd
+if (defaultProdArray && optionMap) {
+  defaultProd = defaultProdArray ? defaultProdArray.value : optionMap[0].value
+} else {
+  defaultProd = 'all'
+}
 const defaultClasses = ['exampleblock', 'sect2', 'sect1']
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/src/js/60-docs-roles.js
+++ b/src/js/60-docs-roles.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // label could be eg aura-db-enterprise - we use the full label
     // label could be eg new-5.20 - we use 'new' for the label and add the version as text
-    label = (rolesData[label] && rolesData[label].category !== 'version') ? label : labelParts[0]
+    label = (rolesData[label] && rolesData[label].labelCategory !== 'version') ? label : labelParts.slice(0,-1).join('-')
 
     // ignore labels that are not defined in rolesData
     if (!rolesData[label]) {
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // get version number for version labels
     if ((rolesData[label].labelCategory === 'version' || rolesData[label].versionText) && labelParts[1]) {
-      labelDetails.data.version = labelParts[1]
+      labelDetails.data.version = labelParts.pop()
       const joinText = rolesData[label].versionText ? rolesData[label].versionText : 'in'
       labelDetails.text = [labelDetails.text, joinText, labelDetails.data.version].join(' ')
     }

--- a/src/js/60-docs-roles.js
+++ b/src/js/60-docs-roles.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // label could be eg aura-db-enterprise - we use the full label
     // label could be eg new-5.20 - we use 'new' for the label and add the version as text
-    label = (rolesData[label] && rolesData[label].labelCategory !== 'version') ? label : labelParts.slice(0,-1).join('-')
+    label = (rolesData[label] && rolesData[label].labelCategory !== 'version') ? label : labelParts.slice(0, -1).join('-')
 
     // ignore labels that are not defined in rolesData
     if (!rolesData[label]) {

--- a/src/js/data/rolesData.json
+++ b/src/js/data/rolesData.json
@@ -140,6 +140,12 @@
         "labelCategory": "version",
         "displayText": "Beta"
     },
+    "betaUntil":{
+        "description": "The feature or function was in beta until the version specified",
+        "labelCategory": "version",
+        "displayText": "Beta",
+        "versionText": "until"
+    },
     "deprecated":{
         "labelCategory": "version",
         "displayText": "Deprecated"

--- a/src/js/data/rolesData.json
+++ b/src/js/data/rolesData.json
@@ -140,7 +140,7 @@
         "labelCategory": "version",
         "displayText": "Beta"
     },
-    "betaUntil":{
+    "beta-until":{
         "description": "The feature or function was in beta until the version specified",
         "labelCategory": "version",
         "displayText": "Beta",

--- a/src/partials/nav-selectors.hbs
+++ b/src/partials/nav-selectors.hbs
@@ -17,7 +17,7 @@
 
     <select data-current="{{@root.page.version}}" class="version-selector dropdown-styles">
       {{#each page.versions}}
-      {{#unless (or this.prerelease (and (eq this.version @root.page.version) (eq @root.page.attributes.theme 'cheat-sheet') ))}}
+      {{#unless this.prerelease}}
       <option
         data-version="{{this.displayVersion}}"
         value="{{{relativize this.url}}}"


### PR DESCRIPTION
For new and deprectaed labels it is already possible to include a version number. Although we have a generic `beta` label that can be used to display just the text `Beta`, there is no way to display a version with the text, for example `Beta until 5.12`. 

This PR adds a new `label--beta-until-<version>` role to be used for beta labels where a version number is also required.