### PR TITLE
Fix version selector bugs

### DIFF
--- a/src/js/50-cheat-sheet-toggle.js
+++ b/src/js/50-cheat-sheet-toggle.js
@@ -26,8 +26,14 @@ const prodMatrix = {
 
 // get the default product from optionMap
 const defaultProdArray = optionMap.find((prod) => prod.default === 'true')
-const defaultProd = defaultProdArray ? defaultProdArray.value : optionMap[0].value
 
+// display for 'all' products unless a differnt value is specified via attributes in source
+let defaultProd
+if (defaultProdArray && optionMap) {
+  defaultProd = defaultProdArray ? defaultProdArray.value : optionMap[0].value
+} else {
+  defaultProd = 'all'
+}
 const defaultClasses = ['exampleblock', 'sect2', 'sect1']
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/src/partials/nav-selectors.hbs
+++ b/src/partials/nav-selectors.hbs
@@ -17,7 +17,7 @@
 
     <select data-current="{{@root.page.version}}" class="version-selector dropdown-styles">
       {{#each page.versions}}
-      {{#unless (or this.prerelease (and (eq this.version @root.page.version) (eq @root.page.attributes.theme 'cheat-sheet') ))}}
+      {{#unless this.prerelease}}
       <option
         data-version="{{this.displayVersion}}"
         value="{{{relativize this.url}}}"


### PR DESCRIPTION
Recent updates in the version selector, and previous changes that were specific to the cheat sheet, meant the version of the cheat that is being displayed was excluded from the version selector.

This PR fixes that and a bug in the code for defining the default product to display.