### PR TITLE
Select custom label or hide label in selectors

### DIFF
--- a/preview-src/labels.adoc
+++ b/preview-src/labels.adoc
@@ -1,4 +1,6 @@
 = Labels
+:page-selector-label: Custom version label
+// :page-selector-hide-label: true
 
 
 == All the labels

--- a/src/partials/nav-selectors.hbs
+++ b/src/partials/nav-selectors.hbs
@@ -24,7 +24,7 @@
         {{#if (eq this.version @root.page.version)}} selected{{/if}}
         {{~#if this.missing}} disabled{{/if}}
       >
-        Version {{ this.displayVersion }}{{#if (and @root.page.attributes.nav-indicate-latest (eq this.version @root.page.latest.version)) }} (latest){{/if}}
+        {{#unless @root.page.attributes.selector-hide-label }}{{#with (or @root.page.attributes.selector-label 'Version') }}{{{this}}} {{/with}}{{/unless}}{{ this.displayVersion }}{{#if (and @root.page.attributes.nav-indicate-latest (eq this.version @root.page.latest.version)) }} (latest){{/if}}
       </option>
       {{/unless}}
       {{/each}}


### PR DESCRIPTION
In the version selector we currently prepend the version name (usually a number) with the word 'Version'.

This PR extends the version selector to allow a choice of:
- custom text
- no text

Two attributes are available to control the text that is displayed:

- `page-selector-label`
- `page-selector-hide-label`

These attributes should be set in the usual way by defining in a playbook, antora.yml, or in a page header.

To set custom text:

```
:page-selector-label: Custom version label
```

To have no text, ie just the version name:

```
:page-selector-hide-label: true
```