### PR TITLE
Full role handling

### DIFF
--- a/preview-src/docs-roles.adoc
+++ b/preview-src/docs-roles.adoc
@@ -13,6 +13,14 @@
 Flags sections as Not Available on Aura, Aura DB Enterprise, Enterprise Edition, Fabric, and Deprecated
 --
 
+This page has the `:page-product:` attribute set to `Neo4j`.
+By default, labels that related to a version of a product have `Neo4j` prepended to the version number.
+
+For example, `label--beta-until-5.12` is displayed as `Beta until Neo4j 5.12`.
+
+To override this value, include the product name in the label.
+For example, `label--beta-until-bolt-1.0` is displayed as `Beta until Bolt 1.0`.
+
 
 [role=label--beta-until-bolt-1.0 label--removed-2.0]
 == Adding a product name to versioned labels
@@ -23,37 +31,6 @@ Flags sections as Not Available on Aura, Aura DB Enterprise, Enterprise Edition,
 === Request message `ACK_FAILURE`
 
 The request message `ACK_FAILURE` signals to the server that the client has acknowledged a previous failure and should return to a `READY` state.
-
-The request message `ACK_FAILURE` is only valid in version *1* and *2* and the request message `RESET` should be used in its place in version *3+*.
-
-*Signature:* `0E`
-
-*Fields:* No fields.
-
-*Detail messages*:
-
-No detail messages should be returned.
-
-*Valid summary messages:*
-
-** `SUCCESS`
-** `FAILURE`
-
-The server must be in a `FAILED` state to be able to successfully process an `ACK_FAILURE` request.
-For any other states, receipt of an `ACK_FAILURE` request will be considered a protocol violation and will lead to connection closure.
-
-==== Examples
-.Synopsis
-[source, bolt]
-----
-ACK_FAILURE
-----
-
-.Example
-[source, bolt]
-----
-ACK_FAILURE
-----
 
 
 [role=label--new-5.11 label--beta-until-5.12]

--- a/preview-src/docs-roles.adoc
+++ b/preview-src/docs-roles.adoc
@@ -5,12 +5,55 @@
 :page-banner-text: Lorem ipsum dolor sit est.
 :page-banner-link: https://neo4j.com/docs
 :page-banner-link-text: Link text
+:page-product: Neo4j
 // :page-labels: fabric enterprise-edition alpha test
 
 [abstract]
 --
 Flags sections as Not Available on Aura, Aura DB Enterprise, Enterprise Edition, Fabric, and Deprecated
 --
+
+
+[role=label--beta-until-bolt-1.0 label--removed-2.0]
+== Adding a product name to versioned labels
+
+
+[role=label--beta-until-1.0 label--dynamic-5.22 label--dynamic]
+[[messages-ack-failure]]
+=== Request message `ACK_FAILURE`
+
+The request message `ACK_FAILURE` signals to the server that the client has acknowledged a previous failure and should return to a `READY` state.
+
+The request message `ACK_FAILURE` is only valid in version *1* and *2* and the request message `RESET` should be used in its place in version *3+*.
+
+*Signature:* `0E`
+
+*Fields:* No fields.
+
+*Detail messages*:
+
+No detail messages should be returned.
+
+*Valid summary messages:*
+
+** `SUCCESS`
+** `FAILURE`
+
+The server must be in a `FAILED` state to be able to successfully process an `ACK_FAILURE` request.
+For any other states, receipt of an `ACK_FAILURE` request will be considered a protocol violation and will lead to connection closure.
+
+==== Examples
+.Synopsis
+[source, bolt]
+----
+ACK_FAILURE
+----
+
+.Example
+[source, bolt]
+----
+ACK_FAILURE
+----
 
 
 [role=label--new-5.11 label--beta-until-5.12]

--- a/preview-src/docs-roles.adoc
+++ b/preview-src/docs-roles.adoc
@@ -21,6 +21,9 @@ For example, `label--beta-until-5.12` is displayed as `Beta until Neo4j 5.12`.
 To override this value, include the product name in the label.
 For example, `label--beta-until-bolt-1.0` is displayed as `Beta until Bolt 1.0`.
 
+[role=test-role]
+Paragraph with non-label role.
+
 
 [role=label--beta-until-bolt-1.0 label--removed-2.0]
 == Adding a product name to versioned labels

--- a/src/js/60-docs-roles.js
+++ b/src/js/60-docs-roles.js
@@ -73,10 +73,10 @@ document.addEventListener('DOMContentLoaded', function () {
       text: rolesData[dataLabel].displayText || '',
       joinText: dataVersion ? rolesData[dataLabel].joinText || 'in' : '',
       data: {
-        labelCategory: rolesData[dataLabel].labelCategory || '',
         product: dataVersion ? dataProduct || rolesData[dataLabel].product || contentDataset.product || '' : '',
         version: dataVersion || '',
         function: rolesData[dataLabel].function || '',
+        event: rolesData[dataLabel].labelCategory === 'version' ? dataLabel : '',
       },
     }
 
@@ -127,9 +127,9 @@ document.addEventListener('DOMContentLoaded', function () {
       const labelSpan = createElement('span', `label content-label label--${labelDetails.class}`)
 
       // add dataset to the label
-      if (labelDetails.data.version) labelSpan.dataset.version = labelDetails.data.version
-      if (labelDetails.data.product !== '') labelSpan.dataset.product = labelDetails.data.product
-      if (labelDetails.data.function !== '') labelSpan.dataset.function = labelDetails.data.function
+      for (var d in labelDetails.data) {
+        if (labelDetails.data[d] !== '') labelSpan.dataset[d] = labelDetails.data[d]
+      }
 
       labelSpan.appendChild(document.createTextNode(labelDetails.text))
 
@@ -148,8 +148,10 @@ document.addEventListener('DOMContentLoaded', function () {
         label.classList.add('header-label')
       }
       labelsDiv.append(label)
-      const contentLabel = Array.from(label.classList).find((c) => c.startsWith('label--')).replace('label--', '')
-      roleDiv.dataset[camelCased(contentLabel)] = contentLabel
+
+      for (var d in label.dataset) {
+        roleDiv.dataset[d] = label.dataset[d]
+      }
     }
 
     if (roleDiv.nodeName === 'H1' || headings.includes(roleDiv.firstElementChild.nodeName)) {

--- a/src/js/data/rolesData.json
+++ b/src/js/data/rolesData.json
@@ -130,7 +130,7 @@
     "dynamic":{
         "labelCategory": "function",
         "displayText": "Dynamic",
-        "versionText": "since"
+        "joinText": "since"
     },
     "alpha":{
         "labelCategory": "version",
@@ -144,7 +144,7 @@
         "description": "The feature or function was in beta until the version specified",
         "labelCategory": "version",
         "displayText": "Beta",
-        "versionText": "until"
+        "joinText": "until"
     },
     "deprecated":{
         "labelCategory": "version",

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -1,5 +1,5 @@
 <div id="skip-to-content"></div>
-<article class="doc">
+<article class="doc"{{#with page.attributes.product}} data-product="{{this}}"{{/with}}>
 {{#if (eq page.layout '404')}}
 <h1 class="page">{{{or page.title 'Page Not Found'}}}</h1>
 <div class="paragraph">


### PR DESCRIPTION
Properly handles roles with product names and versions

- `label--beta-until-bolt-1.0`
- `label--beta-until-1.0`

Also allows for `page-product` attribute to be used in labels.

If `:page-product: Neo4j`, for example, `label--new-5.22` is displayed as 'New in Neo4j 5.22'