### PR TITLE
Tweak icon and list spacing

### DIFF
--- a/preview-src/docs-ndl.adoc
+++ b/preview-src/docs-ndl.adoc
@@ -199,7 +199,7 @@ xref:tutorials:index.adoc[All tutorials]
 --
 
 
-[.cards.icon-s.align-center.two-column]
+[.cards.icon-s.align-center]
 == Other resources
 
 === Join forums and discussions

--- a/preview-src/docs-ndl.adoc
+++ b/preview-src/docs-ndl.adoc
@@ -199,7 +199,7 @@ xref:tutorials:index.adoc[All tutorials]
 --
 
 
-[.cards.icon-s.align-center]
+[.cards.icon-s.align-center.two-column]
 == Other resources
 
 === Join forums and discussions

--- a/src/css/docs-ndl.css
+++ b/src/css/docs-ndl.css
@@ -721,7 +721,7 @@ body.docs-ndl .cards .icon span {
 }
 
 /* For the 1st, 3rd etc highlights, move the image to the right */
-body.docs-ndl .widget.highlights:nth-of-type(even) .icon {
+body.docs-ndl .widget.highlights:nth-of-type(odd) .icon {
   order: 1;
 }
 

--- a/src/css/docs-ndl.css
+++ b/src/css/docs-ndl.css
@@ -731,8 +731,8 @@ body.docs-ndl .widget.highlights:nth-of-type(even) .icon {
 } */
 
 /* For the bottom cards */
-body.docs-ndl .cards.two-column .sectionbody > div.sect2 {
-  flex: 0 0 49%;
+body.docs-ndl .cards:nth-last-child(-n+2) .sectionbody {
+  flex: 0 0 152%;
 }
 
 body.docs-ndl body.docs-ndl .cards .sect2 .icon img {
@@ -950,8 +950,7 @@ body.docs-ndl .cards .sect2 .ulist ul li {
     text-align: left;
   }
 
-  body.docs-ndl .cards .sectionbody > div.sect2,
-  body.docs-ndl .cards.two-column .sectionbody > div.sect2 {
+  body.docs-ndl .cards .sectionbody > div.sect2 {
     /* min-width: 90%; */
     flex: 1 1 100%;
   }

--- a/src/css/docs-ndl.css
+++ b/src/css/docs-ndl.css
@@ -731,8 +731,8 @@ body.docs-ndl .widget.highlights:nth-of-type(even) .icon {
 } */
 
 /* For the bottom cards */
-body.docs-ndl .cards:nth-last-child(-n+2) .sectionbody {
-  flex: 0 0 152%;
+body.docs-ndl .cards.two-column .sectionbody > div.sect2 {
+  flex: 0 0 49%;
 }
 
 body.docs-ndl body.docs-ndl .cards .sect2 .icon img {
@@ -950,7 +950,8 @@ body.docs-ndl .cards .sect2 .ulist ul li {
     text-align: left;
   }
 
-  body.docs-ndl .cards .sectionbody > div.sect2 {
+  body.docs-ndl .cards .sectionbody > div.sect2,
+  body.docs-ndl .cards.two-column .sectionbody > div.sect2 {
     /* min-width: 90%; */
     flex: 1 1 100%;
   }

--- a/src/css/docs-ndl.css
+++ b/src/css/docs-ndl.css
@@ -207,8 +207,14 @@ body.docs-ndl .widget .sectionbody {
   border-radius: 1rem;
   border: none;
   padding: 1rem;
+  column-gap: 0;
   row-gap: 0;
-  column-gap: 2rem;
+  justify-content: center;
+  align-content: center;
+}
+
+body.docs-ndl .widget.lists .sectionbody {
+  justify-content: space-between;
 }
 
 body.docs-ndl .widget.banner .sectionbody {
@@ -498,25 +504,20 @@ body.docs-ndl .banner .button {
 
 /* highlights */
 
-body.docs-ndl .highlights .sectionbody > div.openblock {
-  flex: 1 1 40%;
-}
-
-body.docs-ndl .highlights .sectionbody > div.icon {
-  flex: 0 1 52%;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-  padding-left: 4rem;
-  padding-right: 5.438rem;
+body.docs-ndl .highlights .sectionbody > div {
+  flex: 0 1 50%;
+  justify-content: center;
   align-self: center;
+  padding: 1rem;
 }
 
 body.docs-ndl .highlights .sectionbody > div.icon span.image {
   display: flex;
 }
 
-body.docs-ndl .highlights .list {
-  padding-left: 1rem;
+body.docs-ndl .highlights .list,
+body.docs-ndl .highlights .caption {
+  padding-left: 0;
 }
 
 body.docs-ndl .highlights .list ul li {
@@ -719,19 +720,15 @@ body.docs-ndl .cards .icon span {
   display: flex;
 }
 
-body.docs-ndl .widget.highlights .icon {
-  padding: 2rem;
-}
-
 /* For the 1st, 3rd etc highlights, move the image to the right */
-body.docs-ndl .widget.highlights:nth-of-type(odd) .icon {
+body.docs-ndl .widget.highlights:nth-of-type(even) .icon {
   order: 1;
 }
 
 /* We can use this rule to apply styles to the 2nd, 4th highlights etc widget */
-body.docs-ndl .widget.highlights:nth-of-type(even) .openblock {
-  /* margin-right:40px; */
-}
+/* body.docs-ndl .widget.highlights:nth-of-type(even) .openblock {
+  margin-right:40px;
+} */
 
 /* For the bottom cards */
 body.docs-ndl .cards:nth-last-child(-n+2) .sectionbody {

--- a/src/css/docs-ndl.css
+++ b/src/css/docs-ndl.css
@@ -508,11 +508,12 @@ body.docs-ndl .highlights .sectionbody > div {
   flex: 0 1 50%;
   justify-content: center;
   align-self: center;
-  padding: 1rem;
+  padding: 1rem 2rem 1rem;  
 }
 
 body.docs-ndl .highlights .sectionbody > div.icon span.image {
   display: flex;
+  justify-content: center;
 }
 
 body.docs-ndl .highlights .list,
@@ -685,7 +686,7 @@ body.docs-ndl .cards .sect2 a > div {
 body.docs-ndl .highlights .sectionbody > div,
 body.docs-ndl .sect2 a > div,
 body.docs-ndl .sect2 a > h3 {
-  display: flex;
+  display: flow;
 }
 
 body.docs-ndl .cards .sect2 .icon,

--- a/src/css/docs-ndl.css
+++ b/src/css/docs-ndl.css
@@ -508,7 +508,7 @@ body.docs-ndl .highlights .sectionbody > div {
   flex: 0 1 50%;
   justify-content: center;
   align-self: center;
-  padding: 1rem 2rem 1rem;  
+  padding: 1rem 2rem 1rem;
 }
 
 body.docs-ndl .highlights .sectionbody > div.icon span.image {


### PR DESCRIPTION
Adjusts padding and alignment for the highlights widget, bringing better symmetry between the two layouts. (Also flips the order so that the first instance is `image <> list` and the second is `list <> image` to breakup the amount of left-aligned text earlier).