### PR TITLE
Creation of a Labs label for a different page-role

### DIFF
--- a/preview-src/labels.adoc
+++ b/preview-src/labels.adoc
@@ -183,7 +183,7 @@
 </div>
 
 <div class="box">
-  <span class="label label--labs">Labs</span>
+  <span class="label label--labs-label">Labs</span>
 </div>
 
 ++++

--- a/preview-src/labels.adoc
+++ b/preview-src/labels.adoc
@@ -182,6 +182,10 @@
   <span class="label label--cluster-member-single">SINGLE</span>
 </div>
 
+<div class="box">
+  <span class="label label--labs">Labs</span>
+</div>
+
 ++++
 
 == Tables with labels!

--- a/src/css/labels.css
+++ b/src/css/labels.css
@@ -120,6 +120,11 @@ span.label--function {
   color: rgba(var(--colors-lavender-50));
 }
 
+span.label--labs {
+  background: rgba(var(--color-labs));
+  color: rgba(var(--colors-neutral-10));
+}
+
 span.label--current {
   background: rgba(var(--colors-baltic-50));
   color: rgba(var(--colors-baltic-10));

--- a/src/css/labels.css
+++ b/src/css/labels.css
@@ -120,11 +120,6 @@ span.label--function {
   color: rgba(var(--colors-lavender-50));
 }
 
-span.label--labs {
-  background: rgba(var(--color-labs));
-  color: rgba(var(--colors-neutral-10));
-}
-
 span.label--current {
   background: rgba(var(--colors-baltic-50));
   color: rgba(var(--colors-baltic-10));
@@ -237,6 +232,11 @@ span.label--cluster-member-single {
 
 span.label--labs {
   background: var(--color-labs);
+}
+
+span.label--labs-label {
+  background: var(--color-labs);
+  color: rgba(var(--colors-neutral-10));
 }
 
 span.label--graph-academy {

--- a/src/js/data/rolesData.json
+++ b/src/js/data/rolesData.json
@@ -12,7 +12,7 @@
     },
     "labs-label":{
         "description": "Neo4j Labs project label",
-        "labelCategory": "product",
+        "labelCategory": "content",
         "product": "Labs",
         "displayText": "Labs"
     },

--- a/src/js/data/rolesData.json
+++ b/src/js/data/rolesData.json
@@ -10,6 +10,12 @@
         "product": "Labs",
         "displayText": "Labs"
     },
+    "labs-label":{
+        "description": "Neo4j Labs project label",
+        "labelCategory": "product",
+        "product": "Labs",
+        "displayText": "Labs"
+    },
     "graph-academy":{
         "description": "Neo4j Graph Academy",
         "labelCategory": "content",


### PR DESCRIPTION
The page-role "Labs" is already used for the Labs template, so in order to use a Labs label in H2 in an upcoming page in docs, I thought this could be the way to fix it.