### PR TITLE
Restore list markers

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -578,6 +578,14 @@ body {
   padding: 0 0 0 2rem;
 }
 
+.doc ol {
+  list-style-type: decimal;
+}
+
+.doc ul {
+  list-style-type: disc;
+}
+
 .doc ol.arabic {
   list-style-type: decimal;
 }


### PR DESCRIPTION
Chatbot uses Needle styles.

Needle styles set `list-type: none` on `ol` and `ul`

We need to set styles for lists in `.doc` content.