### PR TITLE
Add selectorText to version selector

### DIFF
--- a/src/partials/nav-selectors.hbs
+++ b/src/partials/nav-selectors.hbs
@@ -24,7 +24,7 @@
         {{#if (eq this.version @root.page.version)}} selected{{/if}}
         {{~#if this.missing}} disabled{{/if}}
       >
-        {{#unless @root.page.attributes.selector-hide-label }}{{#with (or @root.page.attributes.selector-label 'Version') }}{{{this}}} {{/with}}{{/unless}}{{ this.displayVersion }}{{#if (and @root.page.attributes.nav-indicate-latest (eq this.version @root.page.latest.version)) }} (latest){{/if}}
+        {{#unless @root.page.attributes.selector-hide-label }}{{#with (or @root.page.attributes.selector-label 'Version') }}{{{this}}} {{/with}}{{/unless}}{{ this.displayVersion }}{{#with this.selectorText }} {{{this}}}{{/with}}{{#if (and @root.page.attributes.nav-indicate-latest (eq this.version @root.page.latest.version)) }} (latest){{/if}}
       </option>
       {{/unless}}
       {{/each}}


### PR DESCRIPTION
Note that this update depends on the `selector-labels` extension added by https://github.com/neo4j/docs-tools/pull/28