### PR TITLE
Graphically clarify home tiles are clickable.

### DIFF
--- a/src/css/docs-ndl.css
+++ b/src/css/docs-ndl.css
@@ -474,7 +474,6 @@ body.docs-ndl .cards .sect2.selectable .description {
 }
 
 body.docs-ndl .cards .sect2.selectable a {
-  cursor: default;
   text-decoration: solid;
 }
 


### PR DESCRIPTION
Tiles in docs landing pages currently have a normal cursor, even when they are clickable. 
With this change, the cursor will be a hand (like on links) when the tile is clickable.