### PR TITLE
Restore canonical link

### DIFF
--- a/src/partials/head-info.hbs
+++ b/src/partials/head-info.hbs
@@ -1,4 +1,3 @@
-    {{#unless (ne page.attributes.no-canonical undefined)}}
     {{#if page.canonicalUrl}}
     {{#with page.canonicalUrl}}
     <link rel="canonical" href="{{{this}}}">
@@ -6,7 +5,7 @@
     {{else}}
     <link rel="canonical" href="https://neo4j.com{{{ page.attributes.canonical-root }}}{{ page.url }}">
     {{/if}}
-    {{/unless}}
+
     {{#unless (eq page.attributes.pagination undefined)}}
     {{#with page.previous}}
     <link rel="prev" href="{{{relativize ./url}}}">
@@ -15,6 +14,7 @@
     <link rel="next" href="{{{relativize ./url}}}">
     {{/with}}
     {{/unless}}
+
     {{#with page.description}}
       <meta name="description" content="{{this}}">
     {{/with}}

--- a/src/partials/head-info.hbs
+++ b/src/partials/head-info.hbs
@@ -1,6 +1,8 @@
     {{#unless (ne page.attributes.no-canonical undefined)}}
     {{#if page.canonicalUrl}}
+    {{#with page.canonicalUrl}}
     <link rel="canonical" href="{{{this}}}">
+    {{/with}}
     {{else}}
     <link rel="canonical" href="https://neo4j.com{{{ page.attributes.canonical-root }}}{{ page.url }}">
     {{/if}}


### PR DESCRIPTION
WIth this change, a canonical link will be added to the head of every page, for example `<link rel="canonical" href="https://neo4j.com/docs/status-codes/2025.01/">`.