### PR TITLE
helper to choose edit this page link text

### DIFF
--- a/preview-src/tables.adoc
+++ b/preview-src/tables.adoc
@@ -1,6 +1,10 @@
 = Tables
 :nofooter:
+:page-theme: docs
 :page-ogtitle: This page uses the page-ogtitle attribute to generate a custom title for SEO meta
+// :page-edit-url-body: Custom raise an issue body text
+// :page-edit-url-title: Custom raise an issue title text
+:page-edit-url-uri: https://github.com/neo4j/docs-cypher/blob/dev/modules/ROOT/pages/queries/index.adoc
 
 .No striping
 // Alternative to stripes attributes is

--- a/src/helpers/edit-url-text.js
+++ b/src/helpers/edit-url-text.js
@@ -1,6 +1,35 @@
 'use strict'
 
+const { posix: path } = require('path')
+
 module.exports = (page) => {
-  if (page.attributes && page.attributes['edit-url-text']) return page.attributes['edit-url-text']
-  return (page.attributes && page.attributes.theme === 'docs') ? 'Raise an issue' : 'Edit this page'
+  const HOSTED_GIT_REPO_RX = /^(?:https?:\/\/|.+@)(git(?:hub|lab)\.com|bitbucket\.org|pagure\.io)[/:](.+?)(?:\.git)?$/
+  const repoPage = page.attributes['edit-url-repo-action'] || 'issues'
+  const repoExtra = repoPage === 'issues' ? 'new' : ''
+  const feedbackTitle = page.attributes['edit-url-title'] || 'Docs Feedback'
+  const feedbackLabels = page.attributes['edit-url-labels'] || ''
+
+  // text for the link is based on the edit-url-text attribute, or page theme
+  const text = (page.attributes && page.attributes['edit-url-text'])
+    ? page.attributes['edit-url-text']
+    : (page.attributes && page.attributes.theme === 'docs')
+      ? 'Raise an issue'
+      : 'Edit this page'
+
+  // url for docs can be derived from page.editUrl
+  // and updated to link to the repo issues page
+  // for other themes, page.editUrl is used
+  let url = page.editUrl
+  if (page.attributes && page.attributes.theme === 'docs') {
+    const match = url.match(HOSTED_GIT_REPO_RX)
+    const editDetails = match[2].split('/')
+    let query = `?title=${feedbackTitle}: ${path.join(...editDetails.slice(4))} (ref: ${editDetails[3]})`
+    query += feedbackLabels !== '' ? `&labels=${feedbackLabels}` : ''
+    url = 'https://' + path.join(match[1], editDetails[0], editDetails[1], repoPage, repoExtra, query)
+  }
+
+  return {
+    text: text,
+    url: encodeURI(url),
+  }
 }

--- a/src/helpers/edit-url-text.js
+++ b/src/helpers/edit-url-text.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = (page) => {
+  if (page.attributes && page.attributes['edit-url-text']) return page.attributes['edit-url-text']
+  return (page.attributes && page.attributes.theme === 'docs') ? 'Raise an issue' : 'Edit this page'
+}

--- a/src/partials/edit-this-page-link.hbs
+++ b/src/partials/edit-this-page-link.hbs
@@ -2,6 +2,8 @@
   {{#if (and page.fileUri (not env.CI))}}
     <div class="edit-this-page"><a href="{{page.fileUri}}">Edit this Page</a></div>
   {{else if (and page.editUrl (or env.FORCE_SHOW_EDIT_PAGE_LINK (not page.origin.private)))}}
-    <div class="edit-this-page"><a href="{{page.editUrl}}">{{#with (edit-url-text page)}}{{{this}}}{{/with}}</a></div>
+    {{#with (edit-url-text page)}}
+    <div class="edit-this-page"><a href="{{{this.url}}}">{{{this.text}}}</a></div>
+    {{/with}}
   {{/if}}
 {{/unless}}

--- a/src/partials/edit-this-page-link.hbs
+++ b/src/partials/edit-this-page-link.hbs
@@ -2,6 +2,6 @@
   {{#if (and page.fileUri (not env.CI))}}
     <div class="edit-this-page"><a href="{{page.fileUri}}">Edit this Page</a></div>
   {{else if (and page.editUrl (or env.FORCE_SHOW_EDIT_PAGE_LINK (not page.origin.private)))}}
-    <div class="edit-this-page"><a href="{{page.editUrl}}">Edit this Page</a></div>
+    <div class="edit-this-page"><a href="{{page.editUrl}}">{{#with (edit-url-text page)}}{{{this}}}{{/with}}</a></div>
   {{/if}}
 {{/unless}}


### PR DESCRIPTION
Allow different text for the 'edit this page' link.

- If the page attribute `page-edit-url-text` is set that value is used.
- If no attribute is set, the text is determined by the `page-theme`.
  - For `docs` pages, the text will be "Raise an issue".
  - For all other pages the text is "Edit this page".
- The default title is 'Docs Feedback' followed by the file path and branch or tag name that the feedback relates to. To replace the 'Docs Feedback' text, use the page attribute `page-edit-url-title`
- Use the page attribute `page-edit-url-body` to provide placeholder text in the body of the issue. The default text is`> Do not include confidential information, personal data, sensitive data, or other regulated data.`
- To add labels to the issue, use the page attribute `page-edit-url-labels` (note that labels will be added only if they already exist in the repo. New labels are not created.)