### PR TITLE
Use page-custom-canonical

### DIFF
--- a/preview-src/tables.adoc
+++ b/preview-src/tables.adoc
@@ -1,6 +1,7 @@
 = Tables
 :nofooter:
 :page-ogtitle: This page uses the page-ogtitle attribute to generate a custom title for SEO meta
+:page-custom-canonical: https://neo4j.com/docs/cypher-manual/current/clauses/where/
 
 .No striping
 // Alternative to stripes attributes is

--- a/src/partials/head-info.hbs
+++ b/src/partials/head-info.hbs
@@ -3,7 +3,13 @@
     <link rel="canonical" href="{{{this}}}">
     {{/with}}
     {{else}}
+    {{#if page.attributes.custom-canonical}}
+    {{#with page.attributes.custom-canonical}}
+    <link rel="canonical" href="{{{this}}}">
+    {{/with}}    
+    {{else}}
     <link rel="canonical" href="https://neo4j.com{{{ page.attributes.canonical-root }}}{{ page.url }}">
+    {{/if}}
     {{/if}}
 
     {{#unless (eq page.attributes.pagination undefined)}}


### PR DESCRIPTION
Set a page-attribute `:page-custom-canonical:` to override the default canonical URL generated by Antora.