### PR TITLE
Fix canonicals (finally)

### DIFF
--- a/src/helpers/neo-canonical-current.js
+++ b/src/helpers/neo-canonical-current.js
@@ -1,0 +1,13 @@
+// The canonical URL for a page has already been calculated by Antora
+// and is available in the page object a page.canonicalUrl
+// if the canonical URL for a page is in the current version of the component
+// we want to modify the canonical by replacing that version with 'current'
+// we can allow for a page attribute to be set to override 'current'
+
+'use strict'
+
+module.exports = (page) => {
+  const re = new RegExp(`/${page.latest.version}/`)
+  const latestVersionPath = `/${(page.attributes['latest-version-path'] || 'current')}/`
+  return page.canonicalUrl.replace(re, latestVersionPath)
+}

--- a/src/partials/head-info.hbs
+++ b/src/partials/head-info.hbs
@@ -1,5 +1,5 @@
     {{#if page.canonicalUrl}}
-    {{#with page.canonicalUrl}}
+    {{#with (neo-canonical-current page)}}
     <link rel="canonical" href="{{{this}}}">
     {{/with}}
     {{else}}

--- a/src/partials/nav-selectors.hbs
+++ b/src/partials/nav-selectors.hbs
@@ -17,9 +17,10 @@
 
     <select id="selector-version" data-current="{{@root.page.version}}" class="version-selector dropdown-styles">
       {{#each page.versions}}
-      {{#unless this.prerelease}}
+      {{#unless (and this.prerelease @root.page.attributes.nav-selectors-hide-prerelease)}}
       <option
         data-version="{{this.displayVersion}}"
+        {{#if this.prerelease }}data-prerelease="{{this.prerelease}}"{{/if}}
         value="{{{relativize this.url}}}"
         {{#if (eq this.version @root.page.version)}} selected{{/if}}
         {{~#if this.missing}} disabled{{/if}}


### PR DESCRIPTION
Requires pre-release versions to be marked as prerelease so Antora doesn't consider them as 'latest'.

Pre-release versions will be included in the version selector, unless `page-nav-selectors-hide-prerelease` is set to true.

This PR also modifies `page.canonicalUrl`. After it is set by Antora, a helper in the ui-bundle checks the value, and if it contains the version name that is the latest version of the page's component, the url is updated by replacing the version name with 'current'. This ensures that all our canonicals point to current (except where there is no equivalent of a page in the latest release. In that case the canonical is self-referencing).