### PR TITLE
Replace version with current if single version and version is defined

### DIFF
--- a/src/helpers/neo-canonical-current.js
+++ b/src/helpers/neo-canonical-current.js
@@ -4,10 +4,14 @@
 // we want to modify the canonical by replacing that version with 'current'
 // we can allow for a page attribute to be set to override 'current'
 
+// if there's only one version of the page, there is no page.latest
+// if the version is ~ there is no version in the path
+// if both of these are true, we return the canonical URL as is
+
 'use strict'
 
 module.exports = (page) => {
-  if (!page.latest && !page.attributes['use-current-mapping']) return page.canonicalUrl
+  if (!page.latest && !page.version) return page.canonicalUrl
   const versionToReplace = page.latest ? page.latest.version : page.version
   const re = new RegExp(`/${versionToReplace}/`)
   const latestVersionPath = `/${(page.attributes['latest-version-path'] || 'current')}/`

--- a/src/helpers/neo-canonical-current.js
+++ b/src/helpers/neo-canonical-current.js
@@ -4,15 +4,14 @@
 // we want to modify the canonical by replacing that version with 'current'
 // we can allow for a page attribute to be set to override 'current'
 
-// if there's only one version of the page, there is no page.latest
-// if the version is ~ there is no version in the path
-// if both of these are true, we return the canonical URL as is
+// if the version is ~ there is no version in the path - we return the canonical URL as is
+// if there's only one version of the page, there is no page.latest - we use page.version
 
 'use strict'
 
 module.exports = (page) => {
-  if (!page.latest && !page.version) return page.canonicalUrl
   const versionToReplace = page.latest ? page.latest.version : page.version
+  if (!versionToReplace) return page.canonicalUrl
   const re = new RegExp(`/${versionToReplace}/`)
   const latestVersionPath = `/${(page.attributes['latest-version-path'] || 'current')}/`
   return page.canonicalUrl.replace(re, latestVersionPath)

--- a/src/helpers/neo-canonical-current.js
+++ b/src/helpers/neo-canonical-current.js
@@ -7,8 +7,9 @@
 'use strict'
 
 module.exports = (page) => {
-  if (!page.latest) return page.canonicalUrl
-  const re = new RegExp(`/${page.latest.version}/`)
+  if (!page.latest && !page.attributes['use-current-mapping']) return page.canonicalUrl
+  const versionToReplace = page.latest ? page.latest.version : page.version
+  const re = new RegExp(`/${versionToReplace}/`)
   const latestVersionPath = `/${(page.attributes['latest-version-path'] || 'current')}/`
   return page.canonicalUrl.replace(re, latestVersionPath)
 }


### PR DESCRIPTION
Use `page.latest` or `page.version` to get a version to replace with `current`.

If the component has a single version there is no `page.latest`. If `version: ~` in antora.yml there is no page.version.

If there's no version to replace, return the canonicalUrl as is.