### PR TITLE
Fix stray HTML tags.

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -3,40 +3,52 @@
     <div class="navbar-brand">
       {{!-- <a class="navbar-item" href="{{{or site.url (or siteRootUrl siteRootPath)}}}"> --}}
       <a class="navbar-item" href="/">
-        <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" />
         {{!-- <link rel="icon" href="{{{uiRootPath}}}/img/favicon.ico" type="image/x-icon"> --}}
         {{!-- <img class="navbar-logo" src="{{{uiRootPath}}}/img/logo.svg" alt="{{ site.title }}" /> --}}
-      </a>
 
-      {{#if (eq page.attributes.theme "docs") }}
+        {{#if (eq page.attributes.theme "docs") }}
+        <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" />
+      </a>
       <a href="/docs/" class="navbar-item no-left-padding" aria-label="Docs">
         Docs
       </a>
-      {{else if (eq page.attributes.theme "cheat-sheet")}}
+        {{else if (eq page.attributes.theme "cheat-sheet")}}
+        <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" />
+      </a>
       <a href="/docs/cypher-cheat-sheet/" class="navbar-item no-left-padding" aria-label="Labs">
         Cypher Cheat Sheet
       </a>
-      {{else if (eq page.attributes.theme "labs")}}
+        {{else if (eq page.attributes.theme "labs")}}
+        <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" />
+      </a>
       <a href="/labs/" class="navbar-item no-left-padding" aria-label="Labs">
         Labs
       </a>
-      {{else if (eq page.attributes.theme "kb")}}
-      {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
+        {{else if (eq page.attributes.theme "kb")}}
+        <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20231023102534/neo4j-logo.svg" alt="{{ site.title }}" />
+        {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
+      </a>
       <a href="/developer/kb/" class="navbar-item no-left-padding page-name-white" aria-label="Knowledge Base">
         Knowledge Base
       </a>
-      {{else if (eq page.attributes.theme "training")}}
-      {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
+        {{else if (eq page.attributes.theme "training")}}
+        <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20231023102534/neo4j-logo.svg" alt="{{ site.title }}" />
+        {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
+      </a>
       <a href="/graphacademy/online-training/" class="navbar-item no-left-padding page-name-white" aria-label="GraphAcademy">
         GraphAcademy
       </a>
-      {{else if (eq page.attributes.theme "graphgists")}}
-      {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
+        {{else if (eq page.attributes.theme "graphgists")}}
+        <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20231023102534/neo4j-logo.svg" alt="{{ site.title }}" />
+        {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
+      </a>
       <a href="/graphgists/" class="navbar-item no-left-padding page-name-white" aria-label="GraphGists">
         GraphGists
       </a>
-      {{else}}
-      {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20231023102534/neo4j-logo.svg" alt="{{ site.title }}" /> --}}
+        {{else}}
+        <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20231023102534/neo4j-logo.svg" alt="{{ site.title }}" />
+        {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
+      </a>
       <a href="/developer/" class="navbar-item no-left-padding page-name-white" aria-label="Developer Guides">
         Developer
       </a>
@@ -64,8 +76,8 @@
           {{/each}}
           </div>
         </div>
+        {{/if}}
       </div>
-      {{/if}}
 
       <button class="navbar-search search-button" data-target="topbar-nav" id="search_open_mobile" aria-label="Open Search">
         <svg width="23px" height="23px" viewBox="0 0 23 23" version="1.1" class="fill-current float-right" id="searchx" role="button" title="Search Website">
@@ -90,7 +102,6 @@
         <span></span>
       </button>
     </div>
-
     <div id="topbar-nav" class="navbar-menu">
       {{#if (eq page.attributes.theme 'cheat-sheet') }}
       <div class="navbar-start">

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -3,45 +3,40 @@
     <div class="navbar-brand">
       {{!-- <a class="navbar-item" href="{{{or site.url (or siteRootUrl siteRootPath)}}}"> --}}
       <a class="navbar-item" href="/">
+        <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" />
         {{!-- <link rel="icon" href="{{{uiRootPath}}}/img/favicon.ico" type="image/x-icon"> --}}
         {{!-- <img class="navbar-logo" src="{{{uiRootPath}}}/img/logo.svg" alt="{{ site.title }}" /> --}}
+      </a>
 
       {{#if (eq page.attributes.theme "docs") }}
-      <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" />
       <a href="/docs/" class="navbar-item no-left-padding" aria-label="Docs">
         Docs
       </a>
       {{else if (eq page.attributes.theme "cheat-sheet")}}
-      <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" />
       <a href="/docs/cypher-cheat-sheet/" class="navbar-item no-left-padding" aria-label="Labs">
         Cypher Cheat Sheet
       </a>
       {{else if (eq page.attributes.theme "labs")}}
-      <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" />
       <a href="/labs/" class="navbar-item no-left-padding" aria-label="Labs">
         Labs
       </a>
       {{else if (eq page.attributes.theme "kb")}}
-      <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20231023102534/neo4j-logo.svg" alt="{{ site.title }}" />
       {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
       <a href="/developer/kb/" class="navbar-item no-left-padding page-name-white" aria-label="Knowledge Base">
         Knowledge Base
       </a>
       {{else if (eq page.attributes.theme "training")}}
-      <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20231023102534/neo4j-logo.svg" alt="{{ site.title }}" />
       {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
       <a href="/graphacademy/online-training/" class="navbar-item no-left-padding page-name-white" aria-label="GraphAcademy">
         GraphAcademy
       </a>
       {{else if (eq page.attributes.theme "graphgists")}}
-      <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20231023102534/neo4j-logo.svg" alt="{{ site.title }}" />
       {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
       <a href="/graphgists/" class="navbar-item no-left-padding page-name-white" aria-label="GraphGists">
         GraphGists
       </a>
       {{else}}
-      <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20231023102534/neo4j-logo.svg" alt="{{ site.title }}" />
-      {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20230926084108/Logo_FullColor_RGB_TransBG.svg" alt="{{ site.title }}" /> --}}
+      {{!-- <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20231023102534/neo4j-logo.svg" alt="{{ site.title }}" /> --}}
       <a href="/developer/" class="navbar-item no-left-padding page-name-white" aria-label="Developer Guides">
         Developer
       </a>
@@ -69,8 +64,8 @@
           {{/each}}
           </div>
         </div>
-        {{/if}}
       </div>
+      {{/if}}
 
       <button class="navbar-search search-button" data-target="topbar-nav" id="search_open_mobile" aria-label="Open Search">
         <svg width="23px" height="23px" viewBox="0 0 23 23" version="1.1" class="fill-current float-right" id="searchx" role="button" title="Search Website">
@@ -95,6 +90,7 @@
         <span></span>
       </button>
     </div>
+
     <div id="topbar-nav" class="navbar-menu">
       {{#if (eq page.attributes.theme 'cheat-sheet') }}
       <div class="navbar-start">


### PR DESCRIPTION
Pages currently have two stray tags - major browsers seem to render them well anyway, but there's no good reason to rely on that.

To fix the missing closing `</a>` in the logo link, I also incorporated the fact that we've retired developer guides, so that an extra logo (white logo on black background) is not needed anymore. If this assumption is not valid, I'll revise.

![stray-tags](https://github.com/user-attachments/assets/d982a5fe-23e1-4c15-8c3a-47a0f5d8b60c)
