### PR TITLE
Ensure only heading element text is used

### DIFF
--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -12,7 +12,7 @@
   var selectors = document.querySelector('.nav-container .selectors')
   var selectorsHeight = selectors ? selectors.getBoundingClientRect().height : 0
   var headingSelector = []
-  for (var l = 0; l <= levels; l++) headingSelector.push(l ? '.sect' + l + '>h' + (l + 1) + '[id]' : 'h1[id].sect0')
+  for (var l = 0; l <= levels; l++) headingSelector.push(l ? '.sect' + l + ':not(.discrete)>h' + (l + 1) + '[id]' : 'h1[id].sect0')
   var headings = find(headingSelector.join(','), article)
 
   var menu = sidebar.querySelector('.toc-menu-placeholder')

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -29,7 +29,9 @@
   var links = {}
   var list = headings.reduce(function (accum, heading) {
     var link = document.createElement('a')
-    link.textContent = [...heading.childNodes].reduce((acc, el) => { return acc + (el.nodeType === Node.TEXT_NODE ? el.textContent : '') }, '')
+    var headingClone = heading.cloneNode(true)
+    headingClone.querySelectorAll('div, a').forEach(function (el) { el.remove() })
+    link.innerHTML = headingClone.innerHTML
     links[(link.href = '#' + heading.id)] = link
     var listItem = document.createElement('li')
     listItem.dataset.level = parseInt(heading.nodeName.slice(1)) - 1

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -29,7 +29,7 @@
   var links = {}
   var list = headings.reduce(function (accum, heading) {
     var link = document.createElement('a')
-    link.textContent = heading.textContent
+    link.textContent = [...heading.childNodes].reduce((acc, el) => { return acc + (el.nodeType === Node.TEXT_NODE ? el.textContent : '') }, '')
     links[(link.href = '#' + heading.id)] = link
     var listItem = document.createElement('li')
     listItem.dataset.level = parseInt(heading.nodeName.slice(1)) - 1


### PR DESCRIPTION
This PR is required by a future change to how roles on headings are handled.

Currently labels are processed by javascript when a page is loaded in a browser. We are adding an extension to convert roles into labels during the asciidoc to html conversion so that their metadata (dataset attributes) are part of the raw HTML and can be used by tools that parse the HTML.

This PR ensures that only the text content of the heading element is used for the entries in the 'Contents' nav section of a page.