### PR TITLE
fix cheat sheet toc

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -314,6 +314,8 @@ page:
           class: 'aura-dbp'
         - name: 'AuraDB Virtual Dedicated Cloud'
           class: 'aura-dbe'
+        - name: 'AuraDB Business Critical'
+          class: 'aura-dbc'
         - name: 'AuraDS Professional'
           class: 'aura-dsp'
         - name: 'AuraDS Enterprise'

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -30,8 +30,13 @@
   var list = headings.reduce(function (accum, heading) {
     var link = document.createElement('a')
     var headingClone = heading.cloneNode(true)
-    headingClone.querySelectorAll('div, a').forEach(function (el) { el.remove() })
-    link.innerHTML = headingClone.innerHTML
+    // console.log(headingClone)
+    headingClone.querySelectorAll('div, a.anchor').forEach(function (el) { el.remove() })
+    if (headingClone.querySelector('a')) {
+      link.textContent = headingClone.textContent
+    } else {
+      link.innerHTML = headingClone.innerHTML
+    }
     links[(link.href = '#' + heading.id)] = link
     var listItem = document.createElement('li')
     listItem.dataset.level = parseInt(heading.nodeName.slice(1)) - 1


### PR DESCRIPTION
A recent change to how the titles for Page Contents are generated created a bug in the Cheat Sheet where the titles were not displayed in the TOC, because the code was not correctly handling headings that contain links. We don't typically use links in headings in the docs (in fact it should possibly be a style guide recommendation to NOT use links in headings in other docs) but the cheat sheet makes extensive use of this to provide links to the relevant sections of the Cypher Manual.

This PR fixes the issue.