### PR TITLE
Add cypher labels and label event ordering

### DIFF
--- a/src/js/60-docs-roles.js
+++ b/src/js/60-docs-roles.js
@@ -70,6 +70,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var labelDetails = {
       class: dataLabel,
       role: dataLabel,
+      eventOrder: rolesData[dataLabel].eventOrder || -1,
       text: rolesData[dataLabel].displayText || '',
       joinText: dataVersion ? rolesData[dataLabel].joinText || 'in' : '',
       data: {
@@ -133,7 +134,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
       labelSpan.appendChild(document.createTextNode(labelDetails.text))
 
-      labels.push(labelSpan)
+      labels.push(
+        {
+          html: labelSpan,
+          eventOrder: labelDetails.eventOrder,
+        }
+      )
     })
 
     // we only generate labels from defined roles
@@ -143,18 +149,16 @@ document.addEventListener('DOMContentLoaded', function () {
     let labelsLocation = (roleDiv.firstElementChild && headings.includes(roleDiv.firstElementChild.nodeName)) ? roleDiv.firstElementChild : roleDiv
     const labelsDiv = createElement('div', 'labels')
 
-    for (const label of labels) {
+    for (const label of labels.sort((a, b) => a.eventOrder - b.eventOrder)) {
       if (roleDiv.nodeName === 'H1' || headings.includes(roleDiv.firstElementChild.nodeName)) {
-        label.classList.add('header-label')
+        label.html.classList.add('header-label')
       }
-      labelsDiv.append(label)
+      labelsDiv.append(label.html)
 
-      for (var d in label.dataset) {
-        roleDiv.dataset[d] = label.dataset[d]
+      for (var d in label.html.dataset) {
+        roleDiv.dataset[d] = label.html.dataset[d]
       }
     }
-
-    console.log(roleDiv.classList)
 
     if (roleDiv.classList.contains('admonitionblock')) {
       labelsLocation = roleDiv.querySelector('td.content')

--- a/src/js/data/rolesData.json
+++ b/src/js/data/rolesData.json
@@ -22,6 +22,18 @@
         "product": "Graph Academy",
         "displayText": "Graph Academy"
     },
+    "cypher-5":{
+        "description": "Function available in Cypher 5",
+        "labelCategory": "product",
+        "product": "Cypher 5",
+        "displayText": "Cypher 5"
+    },
+    "cypher-25":{
+        "description": "Function available in Cypher 25",
+        "labelCategory": "product",
+        "product": "Cypher 25",
+        "displayText": "Cypher 25"
+    },
     "enterprise":{
         "description": "Function available in Enterprise Edition only",
         "labelCategory": "product",
@@ -122,18 +134,21 @@
         "description": "The feature or function was added in the version stated",
         "labelCategory": "version",
         "displayText": "Introduced",
-        "altDisplayText": "Added"
+        "altDisplayText": "Added",
+        "eventOrder": 1
     },
     "added":{
         "description": "The feature or function was added in the version stated",
         "labelCategory": "version",
         "displayText": "Introduced",
-        "altDisplayText": "Added"
+        "altDisplayText": "Added",
+        "eventOrder": 1
     },
     "changed":{
         "description": "The feature or function was changed in the version stated",
         "labelCategory": "version",
-        "displayText": "Changed"
+        "displayText": "Changed",
+        "eventOrder": 2
     },
     "default":{
         "description": "The value shown is the default value",
@@ -143,7 +158,8 @@
     "discontinued":{
         "description": "The feature is no longer available",
         "labelCategory": "version",
-        "displayText": "Discontinued"
+        "displayText": "Discontinued",
+        "eventOrder": 4        
     },
     "dynamic":{
         "labelCategory": "function",
@@ -152,34 +168,41 @@
     },
     "alpha":{
         "labelCategory": "version",
-        "displayText": "Alpha"
+        "displayText": "Alpha",
+        "eventOrder": 0        
     },
     "beta":{
         "labelCategory": "version",
-        "displayText": "Beta"
+        "displayText": "Beta",
+        "eventOrder": 0        
     },
     "beta-until":{
         "description": "The feature or function was in beta until the version specified",
         "labelCategory": "version",
         "displayText": "Beta",
-        "joinText": "until"
+        "joinText": "until",
+        "eventOrder": 0
     },
     "deprecated":{
         "labelCategory": "version",
-        "displayText": "Deprecated"
+        "displayText": "Deprecated",
+        "eventOrder": 3
     },
     "removed":{
         "labelCategory": "version",
-        "displayText": "Removed"
+        "displayText": "Removed",
+        "eventOrder": 4
     },
     "renamed":{
         "labelCategory": "version",
-        "displayText": "Renamed"
+        "displayText": "Renamed",
+        "eventOrder": 2        
     },
     "updated":{
         "description": "The feature or function was updated in the version stated",
         "labelCategory": "version",
-        "displayText": "Updated"
+        "displayText": "Updated",
+        "eventOrder": 2        
     },
     "fabric":{
         "labelCategory": "function",


### PR DESCRIPTION
Adds roles / labels for `Cypher 5` and `Cypher 25`

Also adds ordering for labels relating to an event or action, such as 'Introduced', 'Deprecated', 'Removed'. Labels are ordered according to the logical sequence of events where multiple event labels are displayed. In other words, an 'Introduced' label appears before a 'Removed' label, for example.