### PR TITLE
Fix extra margin in lists nested within callouts

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -919,6 +919,10 @@ body {
   padding: 0.25rem 0;
 }
 
+.doc .colist.arabic div.ulist {
+  margin: 0;
+}
+
 .doc .conum[data-value] {
   border: 1px solid currentColor;
   border-radius: 100%;


### PR DESCRIPTION
This overwrites the broader `.doc .ulist` directive `margin: 0 0 1.5rem`.

Before
<img width="1004" height="543" alt="Screenshot from 2025-09-24 15-09-06" src="https://github.com/user-attachments/assets/6f59c984-cf0b-4539-b693-956a1b2c828f" />

After
<img width="886" height="514" alt="Screenshot from 2025-09-24 15-08-54" src="https://github.com/user-attachments/assets/637f6681-3295-48f9-92da-ca82c7bc427a" />
