### PR TITLE
resolve rollup highlight issue

### DIFF
--- a/src/js/vendor/highlight.js
+++ b/src/js/vendor/highlight.js
@@ -2,7 +2,7 @@
 ;(function () {
   'use strict'
 
-  var hljs = require('highlight.js')
+  var hljs = require('highlight.js/lib/core')
   window.hljs = hljs
   hljs.registerLanguage('asciidoc', require('highlight.js/lib/languages/asciidoc'))
   hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'))


### PR DESCRIPTION
Something in the way Antora 3.1.13 unzips a ui bundle file is failing with our bundle. Specifically, [this change in load-ui.js](https://gitlab.com/antora/antora/-/commit/d2da28035d369042a93c812f8514bfda4491b601).

We can still use our existing `gulp bundle` to generate ui-bundle.zip and if you pass a local filesystem path to the Antora CLI you can use the generated zip just fine. But when the `ui-bundle-url` is an actual URL. It fails, and it fails silently in a way that doesn't log anything or get as far as generating the _./build_ directory.

I traced it to our use of rollup.js and various rollup plugins. And something about the way we include highlight.js. There may be an option in `@rollup/plugin-commonjs` that resolves the issue, but this change seems to get us the highlight we need. 