### PR TITLE
Allow dots in tab titles

### DIFF
--- a/preview-src/drivers-tabs.adoc
+++ b/preview-src/drivers-tabs.adoc
@@ -31,6 +31,10 @@ Numeric prefix + word suffix (6-1-and-later → "6.1 and later")
 ======
 Word + numeric + word (Version-6-1-and-later → "Version 6.1 and later")
 ======
+[.include-with-Version-6-2-and-6-3]
+======
+Multiple version occurrences (Version-6-2-and-6-3 → "Version 6.2 and 6.3")
+======
 ====
 
 == Version number tab titles — role= notation
@@ -56,6 +60,10 @@ Version + word suffix (role=include-with-6.1-and-later → "6.1 and later")
 [role=include-with-Version-6.1-and-later]
 ======
 Word + version + word (role=include-with-Version-6.1-and-later → "Version 6.1 and later")
+======
+[role=include-with-Version-6.2-and-6.3]
+======
+Multiple version occurrences (role=include-with-Version-6.2-and-6.3 → "Version 6.2 and 6.3")
 ======
 ====
 

--- a/preview-src/drivers-tabs.adoc
+++ b/preview-src/drivers-tabs.adoc
@@ -7,27 +7,58 @@ From 4.2 on, the Drivers Manual is split into a separate manual per language.
 
 GDS also uses tabs, but they have a different list of tab separators. Rather than tab on languages, they tab on modes (mutate, stats, stream, train, write) and output tab text as _<mode> mode_ eg _Stream mode_.
 
+== Version number tab titles — dot notation
+
 [.tabbed-example]
 ====
-[.include-with-macos]
-[[mac-os-bit]]
+[.include-with-6-1]
 ======
-Tab for macOS
+Pure major.minor (6-1 → "6.1")
 ======
-[.include-with-linux]
-[[linux-bit]]
+[.include-with-6-1-2]
 ======
-Tab for Linux
+Patch release (6-1-2 → "6.1.2")
 ======
-[.include-with-windows]
+[.include-with-windows-8-1]
 ======
-Tab for Linux
+Word prefix + numeric suffix (windows-8-1 → "Windows 8.1")
 ======
-[.include-with-whatever]
+[.include-with-6-1-and-later]
 ======
-Tab for whatever
+Numeric prefix + word suffix (6-1-and-later → "6.1 and later")
+======
+[.include-with-Version-6-1-and-later]
+======
+Word + numeric + word (Version-6-1-and-later → "Version 6.1 and later")
 ======
 ====
+
+== Version number tab titles — role= notation
+
+[.tabbed-example]
+====
+[role=include-with-6.1]
+======
+Pure major.minor (role=include-with-6.1 → "6.1")
+======
+[role=include-with-6.1.2]
+======
+Patch release (role=include-with-6.1.2 → "6.1.2")
+======
+[role=include-with-windows-8.1]
+======
+Word prefix + version (role=include-with-windows-8.1 → "Windows 8.1")
+======
+[role=include-with-6.1-and-later]
+======
+Version + word suffix (role=include-with-6.1-and-later → "6.1 and later")
+======
+[role=include-with-Version-6.1-and-later]
+======
+Word + version + word (role=include-with-Version-6.1-and-later → "Version 6.1 and later")
+======
+====
+
 
 == Example drivers manual content
 
@@ -587,7 +618,7 @@ Tab for whatever
 
 [.tabbed-example]
 ====
-[.include-with-macos.label--macos]
+[.include-with-macos.label--mac-os]
 ======
 Tab for macOS
 ======
@@ -621,7 +652,7 @@ Tab for Linux
 ======
 [.include-with-windows]
 ======
-Tab for Linux
+Tab for W
 ======
 [.include-with-whatever]
 ======

--- a/src/js/08-tabs-block.js
+++ b/src/js/08-tabs-block.js
@@ -29,24 +29,25 @@ document.addEventListener('DOMContentLoaded', function () {
       default: {
         var parts = lang.split('-')
         var isNum = function (p) { return /^\d+$/.test(p) }
-        // find the first contiguous numeric run and treat it as a version number
-        var numStart = parts.length
-        var numEnd = parts.length
-        for (var i = 0; i < parts.length; i++) {
-          if (isNum(parts[i])) {
-            numStart = i
-            numEnd = i
-            while (numEnd < parts.length && isNum(parts[numEnd])) numEnd++
-            break
+        var hasNum = parts.some(isNum)
+        if (hasNum) {
+          var result = []
+          var i = 0
+          var firstWordGroup = true
+          while (i < parts.length) {
+            if (isNum(parts[i])) {
+              var runStart = i
+              while (i < parts.length && isNum(parts[i])) i++
+              result.push(parts.slice(runStart, i).join('.'))
+            } else {
+              var wordStart = i
+              while (i < parts.length && !isNum(parts[i])) i++
+              var words = parts.slice(wordStart, i).join(' ')
+              result.push(firstWordGroup ? capitalizeFirstLetter(words) : words)
+              firstWordGroup = false
+            }
           }
-        }
-        if (numStart < parts.length) {
-          var before = parts.slice(0, numStart)
-          var after = parts.slice(numEnd)
-          var versionStr = parts.slice(numStart, numEnd).join('.')
-          cased = (before.length ? capitalizeFirstLetter(before.join(' ')) + ' ' : '') +
-            versionStr +
-            (after.length ? ' ' + after.join(' ') : '')
+          cased = result.join(' ')
         } else {
           cased = capitalizeFirstLetter(lang.replaceAll('-', ' '))
         }

--- a/src/js/08-tabs-block.js
+++ b/src/js/08-tabs-block.js
@@ -26,8 +26,31 @@ document.addEventListener('DOMContentLoaded', function () {
       case 'macos':
         cased = 'macOS'
         break
-      default:
-        cased = capitalizeFirstLetter(lang.replaceAll('-', ' '))
+      default: {
+        var parts = lang.split('-')
+        var isNum = function (p) { return /^\d+$/.test(p) }
+        // find the first contiguous numeric run and treat it as a version number
+        var numStart = parts.length
+        var numEnd = parts.length
+        for (var i = 0; i < parts.length; i++) {
+          if (isNum(parts[i])) {
+            numStart = i
+            numEnd = i
+            while (numEnd < parts.length && isNum(parts[numEnd])) numEnd++
+            break
+          }
+        }
+        if (numStart < parts.length) {
+          var before = parts.slice(0, numStart)
+          var after = parts.slice(numEnd)
+          var versionStr = parts.slice(numStart, numEnd).join('.')
+          cased = (before.length ? capitalizeFirstLetter(before.join(' ')) + ' ' : '') +
+            versionStr +
+            (after.length ? ' ' + after.join(' ') : '')
+        } else {
+          cased = capitalizeFirstLetter(lang.replaceAll('-', ' '))
+        }
+      }
     }
     return cased
   }
@@ -139,7 +162,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // add sections for each language from driver manual html output format
       tabsList.forEach(function (lang) {
-        tab.querySelectorAll('.include-with-' + lang).forEach(function (block) {
+        tab.querySelectorAll('[class~="include-with-' + lang + '"]').forEach(function (block) {
           block.setAttribute('data-title', lang)
           block.setAttribute('data-lang', lang)
           elements.push(block)


### PR DESCRIPTION
This PR supports version numbers as tab titles in tabbed examples

Tab identifiers containing version numbers (e.g. 6.1, 8.1, 6.1 and later) previously couldn't be used because:

- The AsciiDoc shorthand [.include-with-6-1] rendered as "6 1" rather than "6.1"
- The role=include-with-6.1 form (which does support dots in the class value) was silently broken — querySelectorAll('.include-with-6.1') is invalid CSS and matched nothing

### Changes to 08-tabs-block.js

- Replaced the CSS class selector (.include-with-X) with an attribute selector ([class~="include-with-X"]) so that dots in class names are handled correctly
- Updated casedLang to detect a contiguous numeric run anywhere in a hyphenated slug and join it with dots, leaving surrounding words as-is:
  - 6-1 → "6.1"
  - 6-1-2 → "6.1.2"
  - windows-8-1 → "Windows 8.1"
  - 6-1-and-later → "6.1 and later"
  - Version-6-1-and-later → "Version 6.1 and later"

Both authoring forms now work: [.include-with-6-1] (hyphens, version detected in JS) and [role=include-with-6.1] (dots, handled by the attribute selector fix).

### Changes to preview-src/drivers-tabs.adoc

- added two test sections covering all variants in both notations.