### PR TITLE
Fix missing css styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /public/
 build/
 yarn.lock
+.claude

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -61,7 +61,7 @@ b,
 dt,
 strong,
 th {
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
 }
 
 em em { /* stylelint-disable-line */

--- a/src/css/cheat-sheet.css
+++ b/src/css/cheat-sheet.css
@@ -231,7 +231,7 @@ body.cheat-sheet aside.nav .selectors {
 }
 
 body.cheat-sheet aside.nav .selectors .dropdown-label {
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
 }
 
 body.cheat-sheet .toc-menu-placeholder h2 {
@@ -258,7 +258,7 @@ body.cheat-sheet .toc .toc-menu li a {
 }
 
 body.cheat-sheet .toc .toc-menu li[data-level="1"] a {
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
 }
 
 body.cheat-sheet .toc .toc-menu li[data-level="2"] a {
@@ -523,7 +523,7 @@ body.cheat-sheet span.label.hidden,
   }
 
   body.cheat-sheet .toc-menu-placeholder li[data-level="1"] {
-    border-bottom: 1px dotted rgba(var(--color-baltic-30));
+    border-bottom: 1px dotted var(--palette-baltic-30);
     /* background-color: rgba(var(--palette-neutral-20)); */
     /* margin-left: 0; */
     width: 100%;
@@ -539,7 +539,7 @@ body.cheat-sheet span.label.hidden,
     display: block;
     padding: 0 0.5rem;
 
-    /* border: 1px dotted var(--color-blue-300); */
+    /* border: 1px dotted var(--palette-baltic-20); */
   }
 
   /* body.cheat-sheet .toc-menu-placeholder li[data-level="2"]::after {

--- a/src/css/code.css
+++ b/src/css/code.css
@@ -22,7 +22,7 @@
 
 .doc .code-header div {
   padding: 0.25rem 0;
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
 }
 
 .doc .listingblock .code-spacer {
@@ -58,7 +58,7 @@
   border: 0 none;
   padding: 0.6rem 0;
   border-radius: 0.175rem;
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
   line-height: 1;
   text-align: center;
 }
@@ -70,7 +70,7 @@
   margin: 0.25rem 0 0.25rem 0.5rem;
   padding: 0.6rem;
   border-radius: 0.175rem;
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
   line-height: 1;
   text-align: center;
 }
@@ -227,7 +227,7 @@
 }
 
 .doc .code-results button:focus {
-  color: var(--color-green-600);
+  color: var(--palette-forest-30);
   outline: none;
 }
 
@@ -287,8 +287,8 @@
 }
 
 .doc .code-results .error {
-  border-left: 4px solid var(--color-red-600);
-  color: var(--color-red-600);
+  border-left: 4px solid var(--palette-hibiscus-35);
+  color: var(--palette-hibiscus-35);
   padding: 8px;
   border-radius: 0;
 }

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -70,6 +70,7 @@ body {
 
 .doc h6 {
   font-size: var(--doc-font-size-h5);
+  font-weight: 600;
 }
 
 .doc h1 code,

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -254,7 +254,7 @@ body {
 
 .doc .image.rounded {
   padding: 12px;
-  box-shadow: 0 0 5px 1px var(--color-blue-200) !important;
+  box-shadow: 0 0 5px 1px var(--palette-baltic-15) !important;
   background: var(--palette-neutral-10);
   border-radius: 50%;
   line-height: 1;
@@ -502,7 +502,7 @@ body {
 }
 
 .doc .admonitionblock.warning a.btn {
-  background-color: var(--color-red-600);
+  background-color: var(--palette-hibiscus-35);
 }
 
 .doc .admonitionblock.warning a {
@@ -519,7 +519,7 @@ body {
 }
 
 /* .doc .admonitionblock.caution a:hover {
-  color: var(--color-orange-400);
+  color: var(--palette-marigold-25);
 } */
 
 .doc .admonitionblock.caution a.btn {
@@ -536,7 +536,7 @@ body {
 }
 
 /* .doc .admonitionblock.tip a:hover {
-  color: var(--color-blue-500);
+  color: var(--palette-baltic-30);
 } */
 
 .doc .admonitionblock.tip a.btn {
@@ -570,7 +570,7 @@ body {
 }
 
 /* .doc .admonitionblock.important a:hover {
-  color: var(--color-purple-500);
+  color: var(--palette-lavender-30);
 } */
 
 .doc .admonitionblock.important a.btn {
@@ -1033,7 +1033,7 @@ body {
 .doc .menuseq i.caret::before {
   content: "\203a";
   font-size: 1.1em;
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
   line-height: calc(1 / 1.1);
 }
 
@@ -1111,60 +1111,60 @@ body {
   display: inline-block;
   padding: 0.2rem 0.8rem;
   border-radius: 0.25rem;
-  background: var(--color-blue-200);
-  color: var(--color-blue-700);
+  background: var(--palette-baltic-15);
+  color: var(--palette-baltic-50);
   font-weight: 600;
   font-size: 0.7rem;
 }
 
 .doc .paragraph.expertise.Intermediate p {
-  background: var(--color-orange-200);
-  color: var(--color-orange-700);
+  background: var(--palette-marigold-15);
+  color: var(--palette-marigold-50);
 }
 
 .doc .paragraph.expertise.Advanced p {
-  background: var(--color-green-200);
-  color: var(--color-green-700);
+  background: var(--palette-forest-10);
+  color: var(--palette-forest-45);
 }
 
 .doc .paragraph.release p {
   display: inline-block;
   padding: 0.2rem 0.8rem;
   border-radius: 0.25rem;
-  background: var(--color-blue-200);
-  color: var(--color-blue-700);
+  background: var(--palette-baltic-15);
+  color: var(--palette-baltic-50);
   font-weight: 600;
   font-size: 0.7rem;
 }
 
 .doc .paragraph.release.core p {
-  background: var(--color-orange-200);
-  color: var(--color-orange-700);
+  background: var(--palette-marigold-15);
+  color: var(--palette-marigold-50);
 }
 
 .doc .paragraph.release.full p {
-  background: var(--color-green-200);
-  color: var(--color-green-700);
+  background: var(--palette-forest-10);
+  color: var(--palette-forest-45);
 }
 
 .doc .paragraph.type p {
   display: inline-block;
   padding: 0.2rem 0.8rem;
   border-radius: 0.25rem;
-  background: var(--color-blue-200);
-  color: var(--color-blue-700);
+  background: var(--palette-baltic-15);
+  color: var(--palette-baltic-50);
   font-weight: 600;
   font-size: 0.7rem;
 }
 
 .doc .paragraph.type.function p {
-  background: var(--color-red-200);
-  color: var(--color-red-700);
+  background: var(--palette-hibiscus-15);
+  color: var(--palette-hibiscus-40);
 }
 
 .doc .paragraph.type.procedure p {
-  background: var(--color-blue-200);
-  color: var(--color-blue-700);
+  background: var(--palette-baltic-15);
+  color: var(--palette-baltic-50);
 }
 
 .doc .responsive-embed,
@@ -1392,7 +1392,7 @@ body {
 } */
 
 .page.unresolved {
-  background: var(--color-red-800);
+  background: var(--palette-hibiscus-45);
   color: var(--palette-neutral-10) !important;
 }
 

--- a/src/css/docs-home.css
+++ b/src/css/docs-home.css
@@ -19,7 +19,7 @@ body.docshome .nav-item .nav-section-header {
   margin-top: 0;
   margin-bottom: 0;
   padding-top: 1.5rem !important;
-  border-top: 1px solid var(--colors-netural-25);
+  border-top: 1px solid var(--colors-neutral-25);
 }
 
 body.docshome .nav-menu .nav-list:first-child .nav-item:first-child .nav-section-header {
@@ -139,7 +139,7 @@ body.docshome:not(.create-applications) .sect2 .icon img {
 body.docshome .sect2 h3 {
   /* z-index: 20; */
   font-size: 1.1rem;
-  color: var(--color-blue-800);
+  color: var(--palette-baltic-55);
   order: 2;
   line-height: 1.5;
   margin: 0.5rem 2rem 0 6rem;

--- a/src/css/docs-ndl.css
+++ b/src/css/docs-ndl.css
@@ -103,7 +103,7 @@ body.docs-ndl .nav-menu .nav-index {
 }
 
 body.docs-ndl .nav-menu .nav-index a {
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
 }
 
 /* body.docs-ndl .nav-item[data-depth="0"] {
@@ -114,7 +114,7 @@ body.docs-ndl .nav-item .nav-section-header {
   margin-top: 0;
   margin-bottom: 0;
   padding-top: 1.5rem !important;
-  border-top: 1px solid var(--colors-netural-25);
+  border-top: 1px solid var(--colors-neutral-25);
 }
 
 body.docs-ndl .nav-menu .nav-list:first-child .nav-item:first-child .nav-section-header {
@@ -417,7 +417,7 @@ body.docs-ndl .paragraph.caption {
   margin: 0;
   /* color: var(--neutral-color); */
   font-feature-settings: 'liga' off, 'clig' off;
-  font-family: var(--font-font-family-h1);
+  font-family: var(--font-family-h1);
   font-size: 32px;
   font-style: normal;
   font-weight: 500;
@@ -780,7 +780,7 @@ body.docs-ndl .lists .sect2 h3 {
   display: flex;
   order: 2;
   margin: 0;
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--weight-semibold);
   width: -webkit-fill-available;
 }
 

--- a/src/css/feedback.css
+++ b/src/css/feedback.css
@@ -85,7 +85,7 @@
 
 .feedback textarea {
   border-radius: 0.25rem;
-  border: 1px solid var(--color-blue-300);
+  border: 1px solid var(--palette-baltic-20);
   background: var(--feedback-textarea-background);
   width: 100%;
   font-family: inherit;

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -347,7 +347,7 @@ html[style*="color-scheme: dark"] #theme-dropdown .theme-icon-light { display: n
   }
 
   .navbar-end .navbar-link {
-    font-weight: var(--body-font-weight-bold);
+    font-weight: var(--body-font-weight-semibold);
     font-size: calc(12 / var(--rem-base) * 1.25rem);
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -657,7 +657,7 @@ html[style*="color-scheme: dark"] #theme-dropdown .theme-icon-light { display: n
   font-size: 0.7rem;
   background-size: cover;
   background-position: center;
-  border: 2px solid var(--color-green-600);
+  border: 2px solid var(--palette-forest-30);
 }
 
 .getting-started-cta .project:hover {

--- a/src/css/landing.css
+++ b/src/css/landing.css
@@ -37,7 +37,7 @@ section.hero h2 {
 section.hero h1::after,
 section.hero h2::after {
   display: block;
-  background-color: var(--color-green-600);
+  background-color: var(--palette-forest-30);
   height: 3px;
   width: 80px;
   margin-top: 1rem;
@@ -227,7 +227,7 @@ body.landing .ulist.buttons li a {
 
   .landing .flex-container .column h3::after {
     display: block;
-    background-color: var(--color-blue-400);
+    background-color: var(--palette-baltic-25);
     height: 2px;
     width: 40px;
     margin-top: 12px;

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -243,7 +243,7 @@ html.is-clipped--nav {
 } */
 
 /* .nav-item.is-active .nav-link {
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
 } */
 
 /* .nav-item.is-active > .nav-item-toggle {
@@ -323,7 +323,7 @@ html.is-clipped--nav {
 }
 
 .nav-panel-explore .component .title {
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
 }
 
 .nav-panel-explore .versions {
@@ -353,7 +353,7 @@ html.is-clipped--nav {
 .nav-panel-explore .component .is-current a {
   border-color: currentColor;
   opacity: 0.9;
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
 }
 
 .nav .label {
@@ -489,7 +489,7 @@ html.is-clipped--nav {
   margin-top: 1rem;
   margin-bottom: 0;
   padding-top: 1.5rem !important;
-  border-top: 1px solid var(--colors-netural-25);
+  border-top: 1px solid var(--colors-neutral-25);
 }
 
 .nav-item .nav-section-header:hover {

--- a/src/css/neo4j-docs.css
+++ b/src/css/neo4j-docs.css
@@ -6,7 +6,7 @@
 }
 
 .doc .paragraph .title {
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
 }
 
 .doc .listingblock.dot {
@@ -113,7 +113,7 @@ span.fabric::after {
   display: inline-block;
   text-align: center;
   font-family: var(--body-font-family);
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--weight-semibold);
   font-style: normal;
   font-size: 0.7rem;
   line-height: var(--doc-line-height);
@@ -264,7 +264,7 @@ span.fabric::after {
 }
 
 .doc .admonitionblock.deprecated a {
-  color: var(--color-red-600);
+  color: var(--palette-hibiscus-35);
 }
 
 .doc pre {
@@ -342,8 +342,8 @@ div.beta-symbol p::before {
   content: '\2A0D';
   margin-left: 0.5em;
   padding: 0 0.5em;
-  background-color: var(--color-purple-200);
-  color: var(--color-purple-700);
+  background-color: var(--palette-lavender-15);
+  color: var(--palette-lavender-45);
   display: inline-flex;
   border-radius: 25%;
 }

--- a/src/css/newsletter.css
+++ b/src/css/newsletter.css
@@ -1,17 +1,17 @@
 .newsletter {
-  background: var(--color-blue-200);
+  background: var(--palette-baltic-15);
   border-radius: 0.5rem;
-  color: var(--color-blue-700);
+  color: var(--palette-baltic-50);
   font-size: calc(14 / var(--rem-base) * 1rem);
   padding: 1rem;
 }
 
 .newsletter h2 {
   font-size: calc(16 / var(--rem-base) * 1rem);
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
   line-height: 1.5;
   margin: 0;
-  color: var(--color-blue-800);
+  color: var(--palette-baltic-55);
 }
 
 .newsletter p {
@@ -19,7 +19,7 @@
 }
 
 .newsletter label {
-  color: var(--color-blue-700);
+  color: var(--palette-baltic-50);
 }
 
 .newsletter .mktoOffset,
@@ -31,10 +31,10 @@
 .newsletter .mktoForm input {
   outline: none;
   margin: 0 !important;
-  border: 1px solid var(--color-blue-300) !important;
+  border: 1px solid var(--palette-baltic-20) !important;
   border-radius: 0.25rem !important;
-  background: var(--color-blue-100) !important;
-  color: var(--color-blue-800) !important;
+  background: var(--palette-baltic-10) !important;
+  color: var(--palette-baltic-55) !important;
 }
 
 .newsletter .mktoLogicalField {
@@ -50,8 +50,8 @@
 }
 
 .newsletter .mktoForm .mktoButtonWrap.mktoSimple .mktoButton {
-  background: var(--color-blue-800) !important;
-  color: var(--color-blue-100) !important;
+  background: var(--palette-baltic-55) !important;
+  color: var(--palette-baltic-10) !important;
   width: 100% !important;
   border-radius: 0.25rem !important;
   border: 0 none;

--- a/src/css/pagination.css
+++ b/src/css/pagination.css
@@ -37,7 +37,7 @@ nav.pagination .next::before {
 }
 
 nav.pagination a {
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
   line-height: 1.3;
   position: relative;
 }

--- a/src/css/research.css
+++ b/src/css/research.css
@@ -40,12 +40,12 @@ body.research .navbar {
 
 .faq-item {
   padding: 10px 0;
-  color: var(--color-black);
+  color: var(--palette-neutral-80);
 }
 
 .faq-question {
   display: flex;
-  color: var(--color-black);
+  color: var(--palette-neutral-80);
 }
 
 .faq-answer {
@@ -222,7 +222,7 @@ body.research .next-steps .sectionbody ol li:last-of-type {
 }
 
 body.research .next-steps .sectionbody ol li p > strong {
-  color: var(--color-black);
+  color: var(--palette-neutral-80);
 }
 
 body.research .next-steps .sectionbody ol li p {
@@ -301,7 +301,7 @@ body.research .paragraph.caption {
   margin-right: 1rem;
   color: var(--neutral-color);
   font-feature-settings: 'liga' off, 'clig' off;
-  font-family: var(--font-font-family-h1);
+  font-family: var(--font-family-h1);
   font-size: 32px;
   font-style: normal;
   font-weight: 500;
@@ -671,7 +671,7 @@ body.research .lists .sect2 h3 {
   /* flex-grow: 1; */
   order: 2;
   margin: 0;
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--weight-semibold);
   width: -webkit-fill-available;
 }
 

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -208,8 +208,8 @@ body.search--active {
 }
 
 .search-results .search-result-item em {
-  background: var(--color-yellow-100);
-  color: var(--color-orange-700);
+  background: var(--palette-lemon-10);
+  color: var(--palette-marigold-50);
   font-style: normal;
   font-weight: 600;
   padding: 0.2rem;
@@ -252,7 +252,7 @@ body.search--active {
 }
 
 .search-results .label--knowledge-base {
-  background: var(--color-orange-600);
+  background: var(--palette-marigold-45);
   color: var(--palette-neutral-10);
 }
 

--- a/src/css/themes.css
+++ b/src/css/themes.css
@@ -157,7 +157,7 @@ body.landing.labs .buttons li a:hover {
 }
 
 body.landing.labs .buttons li a:active {
-  /* background: var(--color-blue-600); */
+  /* background: var(--palette-baltic-45); */
 }
 
 /* body.developer {
@@ -178,7 +178,7 @@ body.developer .search .search-container .search-form {
 }
 
 body.developer .tableblock .icon i:not(.fa) {
-  color: var(--color-green-600);
+  color: var(--palette-forest-30);
 }
 
 body.developer .navbar .navbar-item.getting-started-cta .navbar-link {
@@ -249,7 +249,7 @@ body.landing.developer .buttons li a:hover {
 }
 
 body.landing.developer .buttons li a:active {
-  background: var(--color-green-600);
+  background: var(--palette-forest-30);
 }
 
 /* KB */
@@ -322,7 +322,7 @@ body.graphgists svg.graphgists {
 body.graphgists .navbar,
 body.graphgists .search .search-container .search-form {
   border-top-color: var(--color-graphgists);
-  border-bottom-color: var(--color-black);
+  border-bottom-color: var(--palette-neutral-80);
 }
 
 .graphgists .navbar-brand #developer {

--- a/src/css/tiles.css
+++ b/src/css/tiles.css
@@ -86,7 +86,7 @@ body.tiles .sect2 {
 
 body.tiles .sect2 h3 {
   font-size: 1rem;
-  color: var(--color-blue-800);
+  color: var(--palette-baltic-55);
   margin-bottom: 0;
 }
 
@@ -111,7 +111,7 @@ body.tiles .sect2 ul li {
 
 body.tiles .sect2 ul li a {
   display: inline-block;
-  color: var(--color-blue-600);
+  color: var(--palette-baltic-45);
   border: 1px solid rgba(var(--palette-neutral-20));
   padding: 0.1rem 0.7rem;
   border-radius: 0.2rem;

--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -24,7 +24,7 @@
 .toc .theme-selector h2 {
   color: var(--toc-heading-font-color);
   font-size: var(--doc-font-size-h5);
-  font-weight: var(--body-font-weight-bold);
+  font-weight: var(--body-font-weight-semibold);
   line-height: 1.5;
   margin: 1rem -0.5px 0;
   padding: 1.5rem 0 1.25rem;

--- a/src/css/training.css
+++ b/src/css/training.css
@@ -47,7 +47,7 @@
 }
 
 .training.landing .course-label {
-  background: linear-gradient(45deg, var(--color-blue-400), var(--color-purple-400));
+  background: linear-gradient(45deg, var(--palette-baltic-25), var(--palette-lavender-20));
   font-size: 12px;
   padding: 2px 8px;
   border-radius: 5px;
@@ -72,12 +72,12 @@
 }
 
 .training.landing a.button.course-action {
-  background-color: var(--color-pink-600);
+  background-color: var(--palette-hibiscus-35);
 }
 
 .training.landing a.button.course-action:hover {
   color: var(--palette-neutral-10);
-  background-color: var(--color-pink-500);
+  background-color: var(--palette-hibiscus-25);
 }
 
 .training.landing a.button.course-action:visited {
@@ -214,7 +214,7 @@
 }
 
 .training-courses .course-card .course-label {
-  background: linear-gradient(45deg, var(--color-blue-400), var(--color-purple-400));
+  background: linear-gradient(45deg, var(--palette-baltic-25), var(--palette-lavender-20));
   font-size: 12px;
   padding: 2px 8px;
   border-radius: 5px;
@@ -256,12 +256,12 @@
 }
 
 .course-actions a.button {
-  background-color: var(--color-pink-600);
+  background-color: var(--palette-hibiscus-35);
 }
 
 .course-actions a.button:hover {
   color: var(--palette-neutral-10);
-  background-color: var(--color-pink-500);
+  background-color: var(--palette-hibiscus-25);
 }
 
 .course-actions a.button:visited {
@@ -282,7 +282,7 @@
 }
 
 .training-courses ul > li a:hover {
-  color: var(--color-pink-600);
+  color: var(--palette-hibiscus-35);
 }
 
 /* Enrollment */
@@ -520,7 +520,7 @@
 
 .training-certification .mktoForm .mktoAsterix,
 .training-enrollment .mktoForm .mktoAsterix {
-  color: var(--color-red-800);
+  color: var(--palette-hibiscus-45);
   display: none;
 }
 
@@ -535,14 +535,14 @@
   text-shadow: none;
   outline: 0;
   user-select: none;
-  background-color: var(--color-red-200);
-  color: var(--color-red-900);
+  background-color: var(--palette-hibiscus-15);
+  color: var(--palette-hibiscus-50);
   padding: 0.65rem;
 }
 
 .training-certification .mktoForm .mktoError .mktoErrorArrow,
 .training-enrollment .mktoForm .mktoError .mktoErrorArrow {
-  background-color: var(--color-red-200);
+  background-color: var(--palette-hibiscus-15);
   border: none;
   outline: 0;
   user-select: none;
@@ -552,7 +552,7 @@
 .training-enrollment .mktoForm button.mktoButton {
   color: var(--palette-neutral-10);
   cursor: pointer;
-  background-color: var(--color-pink-600);
+  background-color: var(--palette-hibiscus-35);
   display: inline-block;
   border-radius: 0.25rem;
   margin: auto;
@@ -563,7 +563,7 @@
 
 .training-certification button.mktoButton:hover,
 .training-enrollment button.mktoButton:hover {
-  background-color: var(--color-pink-500);
+  background-color: var(--palette-hibiscus-25);
 }
 
 .training-certification .mktoForm div,
@@ -646,10 +646,10 @@
 
 .training-certification .course-actions .error,
 .training-enrollment .course-actions .error {
-  background-color: var(--color-red-200);
-  color: var(--color-red-900);
+  background-color: var(--palette-hibiscus-15);
+  color: var(--palette-hibiscus-50);
   padding: 1rem;
-  border-left: 4px solid var(--color-red-600);
+  border-left: 4px solid var(--palette-hibiscus-35);
   border-radius: 0.25rem;
   display: flex;
   width: fit-content;
@@ -657,10 +657,10 @@
 }
 
 .training-certification .course-actions .info {
-  background-color: var(--color-blue-200);
-  color: var(--color-blue-900);
+  background-color: var(--palette-baltic-15);
+  color: var(--palette-baltic-60);
   padding: 1rem;
-  border-left: 4px solid var(--color-blue-600);
+  border-left: 4px solid var(--palette-baltic-45);
   border-radius: 0.25rem;
   display: flex;
   width: fit-content;
@@ -725,7 +725,7 @@ body.training .nav-item .nav-item.is-completed::before {
   margin-left: -1.3rem;
   content: "✓";
   opacity: 1;
-  background-color: var(--color-green-500);
+  background-color: var(--palette-forest-25);
   z-index: 1000;
   color: var(--palette-neutral-10);
   text-align: center;
@@ -756,7 +756,7 @@ body.training .nav-item .nav-item.is-pending::before {
 
 body.training .nav-item .nav-item.is-completed.is-current-page::before,
 body.training .nav-item .nav-item.is-completed:hover::before {
-  background-color: var(--color-green-700);
+  background-color: var(--palette-forest-45);
 }
 
 body.training .nav-item .nav-item.is-current-page::before,
@@ -776,15 +776,15 @@ body.training .button {
 }
 
 #quiz-result.is-success {
-  background-color: var(--color-green-200);
-  color: var(--color-green-900);
-  border-left: 4px solid var(--color-green-600);
+  background-color: var(--palette-forest-10);
+  color: var(--palette-forest-55);
+  border-left: 4px solid var(--palette-forest-30);
 }
 
 #quiz-result.is-error {
-  background-color: var(--color-red-200);
-  color: var(--color-red-900);
-  border-left: 4px solid var(--color-red-600);
+  background-color: var(--palette-hibiscus-15);
+  color: var(--palette-hibiscus-50);
+  border-left: 4px solid var(--palette-hibiscus-35);
 }
 
 #quiz-result > p.paragraph {
@@ -803,29 +803,29 @@ body.training .button {
 
 .training .download-certificate .error {
   position: absolute;
-  background-color: var(--color-blue-200);
-  color: var(--color-blue-900);
-  border-left: 4px solid var(--color-blue-600);
+  background-color: var(--palette-baltic-15);
+  color: var(--palette-baltic-60);
+  border-left: 4px solid var(--palette-baltic-45);
   padding: 1rem;
   border-radius: 0.25rem;
 }
 
 .training .download-certificate .success {
   position: absolute;
-  background-color: var(--color-green-200);
-  color: var(--color-green-900);
-  border-left: 4px solid var(--color-green-600);
+  background-color: var(--palette-forest-10);
+  color: var(--palette-forest-55);
+  border-left: 4px solid var(--palette-forest-30);
   padding: 1rem;
   border-radius: 0.25rem;
 }
 
 .training .download-certificate .success a {
   text-decoration: underline;
-  color: var(--color-green-600);
+  color: var(--palette-forest-30);
 }
 
 .training .download-certificate .success a:hover {
-  color: var(--color-green-500);
+  color: var(--palette-forest-25);
 }
 
 /* ready */
@@ -878,8 +878,8 @@ body.training .button {
   right: 2rem;
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0.25rem;
-  background: var(--color-blue-100);
-  color: var(--color-blue-800);
+  background: var(--palette-baltic-10);
+  color: var(--palette-baltic-55);
   padding: 0.5rem 1rem;
   width: 320px;
   font-size: 0.8rem;

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -24,16 +24,20 @@
 
   /* fonts */
   --rem-base: 18; /* used to compute rem value from desired pixel value (e.g., calc(18 / var(--rem-base) * 1rem) = 18px) */
-  --body-font-weight: var(--font-weight-light);
+  --body-font-weight: var(--body-font-weight-light);
   --body-font-size: 1.0625em; /* 17px */
   --body-font-size--desktop: 1em; /* 18px */
   --body-font-size--print: 0.9375em; /* 15px */
   --body-line-height: 1.5;
   --body-font-color: light-dark(var(--theme-light-color-neutral-text-default), var(--palette-neutral-15));
   --body-font-family: "Public Sans", "Nunito Sans", "Helvetica Neue", helvetica, roboto, arial, sans-serif;
-  --body-font-weight-bold: var(--font-weight-semibold);
+  --body-font-weight-bold: var(--weight-bold); /* 700 */
+  --body-font-weight-semibold: var(--weight-semibold); /* 600 */
+  --body-font-weight-medium: var(--weight-medium); /* 500 */
+  --body-font-weight-normal: var(--weight-normal); /* 400 */
+  --body-font-weight-light: var(--weight-light); /* 300 */
   --monospace-font-family: "Roboto Mono", monospace;
-  --monospace-font-weight-bold: var(--font-weight-medium);
+  --monospace-font-weight-bold: var(--body-font-weight-medium);
   --header-font-family: "Syne Neo", "Public Sans", "Nunito Sans", "Helvetica Neue", helvetica, roboto, arial, sans-serif;
 
   /* base */
@@ -217,8 +221,8 @@
   --doc-font-size-h5: var(--typography-title-5-font-size);
   --doc-font-size-h6: calc(var(--typography-title-6-font-size) * 0.75);
   --heading-font-color: light-dark(var(--theme-light-color-neutral-text-default), var(--theme-dark-color-neutral-text-default));
-  --heading-font-weight: var(--font-weight-normal);
-  --alt-heading-font-weight: var(--body-font-weight-bold);
+  --heading-font-weight: var(--body-font-weight-normal);
+  --alt-heading-font-weight: var(--body-font-weight-semibold);
   --section-divider-color: var(--palette-neutral-20);
 
   /* links */
@@ -331,12 +335,12 @@
   --feedback-positive-color: var(--color-docs);
   --feedback-textarea-background: light-dark(var(--palette-neutral-10), var(--theme-dark-color-neutral-bg-on-bg-weak));
   --feedback-textarea-color: var(--body-font-color);
-  --feedback-primary-background: light-dark(var(--color-blue-100), var(--theme-dark-color-neutral-bg-on-bg-weak));
-  --feedback-primary-border-color: light-dark(var(--color-blue-700), var(--theme-dark-color-neutral-border-weak));
-  --feedback-primary-color: light-dark(var(--color-blue-700), var(--palette-neutral-15));
-  --feedback-secondary-background: light-dark(var(--color-blue-100), var(--theme-dark-color-neutral-bg-strong));
-  --feedback-secondary-border-color: light-dark(var(--color-blue-700), var(--theme-dark-color-neutral-border-weak));
-  --feedback-secondary-color: light-dark(var(--color-blue-700), var(--palette-neutral-15));
+  --feedback-primary-background: light-dark(var(--palette-baltic-10), var(--theme-dark-color-neutral-bg-on-bg-weak));
+  --feedback-primary-border-color: light-dark(var(--palette-baltic-50), var(--theme-dark-color-neutral-border-weak));
+  --feedback-primary-color: light-dark(var(--palette-baltic-50), var(--palette-neutral-15));
+  --feedback-secondary-background: light-dark(var(--palette-baltic-10), var(--theme-dark-color-neutral-bg-strong));
+  --feedback-secondary-border-color: light-dark(var(--palette-baltic-50), var(--theme-dark-color-neutral-border-weak));
+  --feedback-secondary-color: light-dark(var(--palette-baltic-50), var(--palette-neutral-15));
   --feedback-input-background: light-dark(var(--theme-light-color-neutral-bg-strong), var(--theme-dark-color-neutral-bg-strong));
 
   /* footer */

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -4,6 +4,8 @@
 
 {{#if page.attributes.chatbot}}
 <link rel="stylesheet" crossorigin href="{{{ page.attributes.chatbot }}}/index.css">
+{{else}}
+<link rel="stylesheet" href="https://neo4j.com/docs/assets/chatbot/index.css">
 {{/if}}
 
 {{#if page.attributes.cdn}}


### PR DESCRIPTION
Local and PR preview builds look different from published docs because they do not include the chatbot css styles.

The chatbot contains vars that we were using, which were not defined in the css files built for the ui-bundle.

I've added a fallback URL for the chatbot css so it is always present.

I've also fixed the css files so they do not contain vars that are not inherent to the ui-bundle (which should actually make the fallback URL redundant, but we'll keep it as a... well, a fallback...).

We should now have correct styles in previews as well as published docs.